### PR TITLE
fix: underscores inside equations are rendered correctly

### DIFF
--- a/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
@@ -63,19 +63,19 @@ Ring과 유사하지만 살짝 더 좋은 성질을 가진 구조를 가지고 �
 
 조금만 더 확장해서 countable한 연산에 대해서도 허용하고 싶습니다.
 
-**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
+**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup _{n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
 
 Countable한 합집합을 해도 닫혀 있다는 뜻입니다. 조금 생각해보면 마찬가지로 교집합에 대해서도 성립함을 알 수 있습니다.
 
 **참고.** 다음 성질
 
-$$\bigcap_ {n=1}^\infty A_n = A_1 \setminus\bigcup_ {n=1}^\infty (A_1 \setminus A_n)$$
+$$\bigcap _{n=1}^\infty A_n = A_1 \setminus\bigcup _{n=1}^\infty (A_1 \setminus A_n)$$
 
-을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap_ {n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
+을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap _{n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
 
 마찬가지로 algebra도 정의할 수 있습니다.
 
-**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
+**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup _{n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
 
 $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집합을 해도 닫혀 있습니다.
 
@@ -101,9 +101,9 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 2. 쌍마다 서로소인 집합 $A_i \in \mathcal{R}$ 에 대하여
 
-	$$\phi\left( \bigcup_ {i=1}^\infty A_i \right) = \sum_ {i=1}^\infty \phi(A_i)$$
+	$$\phi\left( \bigcup _{i=1}^\infty A_i \right) = \sum _{i=1}^\infty \phi(A_i)$$
 
-	이고 $\displaystyle\bigcup_ {i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
+	이고 $\displaystyle\bigcup _{i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
 
 이제 ‘길이’의 개념을 나타내는 함수를 정의합니다. 이 함수는 측도(measure)라고 합니다.
 
@@ -115,7 +115,7 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 1. $\phi$가 additive이면 쌍마다 서로소인 $A_i \in \mathcal{R}$ 에 대하여 다음이 성립한다.
 
-	$$\phi\left( \bigcup_ {i=1}^n A_i \right) = \sum_ {i=1}^n \phi(A_i).$$
+	$$\phi\left( \bigcup _{i=1}^n A_i \right) = \sum _{i=1}^n \phi(A_i).$$
 
 	이 성질을 *finite additivity*라 부르고, $\phi$는 *finitely additive*하다고 한다.
 
@@ -127,7 +127,7 @@ $\phi(A) \in \mathbb{R}$ 인 $A \in \mathcal{R}$이 존재한다는 가정을 �
 
 1. $\mu$가 **finite** 하다. $\iff$모든 $X \in \mathcal{F}$ 에 대하여 $\mu(X) < \infty$ 이다.
 
-2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup_ {i=1}^\infty F_i = X$ 이다.
+2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup _{i=1}^\infty F_i = X$ 이다.
 
 ## Basic Properties of Set Functions
 
@@ -157,7 +157,7 @@ $\phi$가 set function이라 하자.
 
 	가 성립한다. 귀납법을 적용하면, 모든 $A_i \in \mathcal{R}$에 대하여
 
-	$$\phi\left( \bigcup_ {n=1}^m A_n \right) \leq \sum_ {n=1}^m \phi(A_n)$$
+	$$\phi\left( \bigcup _{n=1}^m A_n \right) \leq \sum _{n=1}^m \phi(A_n)$$
 
 	가 성립한다. 이 때 $A_i$가 반드시 쌍마다 서로소일 필요는 없다. 이 성질을 *finite subadditivity*라 한다.
 
@@ -165,29 +165,29 @@ $\phi$가 set function이라 하자.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \subseteq A_2 \subseteq\cdots$ 이면
 
-$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
+$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup _{n=1}^\infty A_n \right)$$
 
 이 성립한다.
 
-**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A_ {n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
+**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A _{n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
 
-$$\mu(A_n) = \mu\left( \bigcup_ {k=1}^n B_k \right) = \sum_ {k=1}^n \mu(B_k)$$
+$$\mu(A_n) = \mu\left( \bigcup _{k=1}^n B_k \right) = \sum _{k=1}^n \mu(B_k)$$
 
 이고, measure의 countable additivity를 이용하여
 
-$$\lim_ {n\rightarrow\infty} \mu(A_n) = \lim_ {n\rightarrow\infty} \sum_ {k=1}^n \mu(B_k) = \sum_ {n=1}^\infty \mu(B_n) = \mu\left( \bigcup_ {n=1}^{\infty} B_n \right) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
+$$\lim _{n\rightarrow\infty} \mu(A_n) = \lim _{n\rightarrow\infty} \sum _{k=1}^n \mu(B_k) = \sum _{n=1}^\infty \mu(B_n) = \mu\left( \bigcup _{n=1}^{\infty} B_n \right) = \mu\left( \bigcup _{n=1}^\infty A_n \right)$$
 
-임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup_ {n=1}^\infty A_n = \bigcup_ {n=1}^\infty B_n$ 임을 이용한다.
+임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup _{n=1}^\infty A_n = \bigcup _{n=1}^\infty B_n$ 임을 이용한다.
 
 왠지 위 조건을 뒤집어서 $A_1 \supseteq A_2 \supseteq \cdots$ 인 경우 교집합에 대해서도 성립하면 좋을 것 같습니다.
 
-$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right).$$
+$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap _{n=1}^\infty A_n \right).$$
 
 하지만 안타깝게도 조건이 부족합니다. $\mu(A_1) < \infty$ 라는 추가 조건이 필요합니다. 반례는 $A_n = [n, \infty)$를 생각해보면 됩니다. 정리의 정확한 서술은 다음과 같습니다. 증명은 연습문제로 남깁니다.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \supseteq A_2 \supseteq \cdots$ 이고 $\mu(A_1) < \infty$ 이면
 
-$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right)$$
+$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap _{n=1}^\infty A_n \right)$$
 
 이 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
@@ -63,19 +63,19 @@ Ring과 유사하지만 살짝 더 좋은 성질을 가진 구조를 가지고 �
 
 조금만 더 확장해서 countable한 연산에 대해서도 허용하고 싶습니다.
 
-**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup _{n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
+**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
 
 Countable한 합집합을 해도 닫혀 있다는 뜻입니다. 조금 생각해보면 마찬가지로 교집합에 대해서도 성립함을 알 수 있습니다.
 
 **참고.** 다음 성질
 
-$$\bigcap _{n=1}^\infty A_n = A_1 \setminus\bigcup _{n=1}^\infty (A_1 \setminus A_n)$$
+$$\bigcap_ {n=1}^\infty A_n = A_1 \setminus\bigcup_ {n=1}^\infty (A_1 \setminus A_n)$$
 
-을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap _{n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
+을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap_ {n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
 
 마찬가지로 algebra도 정의할 수 있습니다.
 
-**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup _{n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
+**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
 
 $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집합을 해도 닫혀 있습니다.
 
@@ -101,9 +101,9 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 2. 쌍마다 서로소인 집합 $A_i \in \mathcal{R}$ 에 대하여
 
-	$$\phi\left( \bigcup _{i=1}^\infty A_i \right) = \sum _{i=1}^\infty \phi(A_i)$$
+	$$\phi\left( \bigcup_ {i=1}^\infty A_i \right) = \sum_ {i=1}^\infty \phi(A_i)$$
 
-	이고 $\displaystyle\bigcup _{i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
+	이고 $\displaystyle\bigcup_ {i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
 
 이제 ‘길이’의 개념을 나타내는 함수를 정의합니다. 이 함수는 측도(measure)라고 합니다.
 
@@ -115,7 +115,7 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 1. $\phi$가 additive이면 쌍마다 서로소인 $A_i \in \mathcal{R}$ 에 대하여 다음이 성립한다.
 
-	$$\phi\left( \bigcup _{i=1}^n A_i \right) = \sum _{i=1}^n \phi(A_i).$$
+	$$\phi\left( \bigcup_ {i=1}^n A_i \right) = \sum_ {i=1}^n \phi(A_i).$$
 
 	이 성질을 *finite additivity*라 부르고, $\phi$는 *finitely additive*하다고 한다.
 
@@ -127,7 +127,7 @@ $\phi(A) \in \mathbb{R}$ 인 $A \in \mathcal{R}$이 존재한다는 가정을 �
 
 1. $\mu$가 **finite** 하다. $\iff$모든 $X \in \mathcal{F}$ 에 대하여 $\mu(X) < \infty$ 이다.
 
-2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup _{i=1}^\infty F_i = X$ 이다.
+2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup_ {i=1}^\infty F_i = X$ 이다.
 
 ## Basic Properties of Set Functions
 
@@ -157,7 +157,7 @@ $\phi$가 set function이라 하자.
 
 	가 성립한다. 귀납법을 적용하면, 모든 $A_i \in \mathcal{R}$에 대하여
 
-	$$\phi\left( \bigcup _{n=1}^m A_n \right) \leq \sum _{n=1}^m \phi(A_n)$$
+	$$\phi\left( \bigcup_ {n=1}^m A_n \right) \leq \sum_ {n=1}^m \phi(A_n)$$
 
 	가 성립한다. 이 때 $A_i$가 반드시 쌍마다 서로소일 필요는 없다. 이 성질을 *finite subadditivity*라 한다.
 
@@ -165,29 +165,29 @@ $\phi$가 set function이라 하자.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \subseteq A_2 \subseteq\cdots$ 이면
 
-$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup _{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
 
 이 성립한다.
 
-**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A _{n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
+**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A_ {n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
 
-$$\mu(A_n) = \mu\left( \bigcup _{k=1}^n B_k \right) = \sum _{k=1}^n \mu(B_k)$$
+$$\mu(A_n) = \mu\left( \bigcup_ {k=1}^n B_k \right) = \sum_ {k=1}^n \mu(B_k)$$
 
 이고, measure의 countable additivity를 이용하여
 
-$$\lim _{n\rightarrow\infty} \mu(A_n) = \lim _{n\rightarrow\infty} \sum _{k=1}^n \mu(B_k) = \sum _{n=1}^\infty \mu(B_n) = \mu\left( \bigcup _{n=1}^{\infty} B_n \right) = \mu\left( \bigcup _{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \lim_ {n\rightarrow\infty} \sum_ {k=1}^n \mu(B_k) = \sum_ {n=1}^\infty \mu(B_n) = \mu\left( \bigcup_ {n=1}^{\infty} B_n \right) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
 
-임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup _{n=1}^\infty A_n = \bigcup _{n=1}^\infty B_n$ 임을 이용한다.
+임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup_ {n=1}^\infty A_n = \bigcup_ {n=1}^\infty B_n$ 임을 이용한다.
 
 왠지 위 조건을 뒤집어서 $A_1 \supseteq A_2 \supseteq \cdots$ 인 경우 교집합에 대해서도 성립하면 좋을 것 같습니다.
 
-$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap _{n=1}^\infty A_n \right).$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right).$$
 
 하지만 안타깝게도 조건이 부족합니다. $\mu(A_1) < \infty$ 라는 추가 조건이 필요합니다. 반례는 $A_n = [n, \infty)$를 생각해보면 됩니다. 정리의 정확한 서술은 다음과 같습니다. 증명은 연습문제로 남깁니다.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \supseteq A_2 \supseteq \cdots$ 이고 $\mu(A_1) < \infty$ 이면
 
-$$\lim _{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap _{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right)$$
 
 이 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
@@ -35,7 +35,7 @@ $\mathcal{R}$이 집합의 모임이라고 하겠습니다. $\mathcal{R} \neq \v
 
 **정의.** (Power Set) 집합 $X$에 대하여 power set $\mathcal{P}(X)$는 다음과 같이 정의한다.
 
-$$\mathcal{P}(X) = \lbrace A : A \subseteq X\rbrace .$$
+$$\mathcal{P}(X) = \lbrace A : A \subseteq X\rbrace.$$
 
 Ring과 유사하지만 살짝 더 좋은 성질을 가진 구조를 가지고 논의를 전개합니다.
 
@@ -87,7 +87,7 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 정의역이 $\mathcal{R}$으로, 집합의 모임입니다. 즉 $\phi$는 집합을 받아 $\overline{\mathbb{R}}$과 대응시키는 함수임을 알 수 있습니다.
 
-우리는 ‘길이’ 함수를 정의하고자 합니다. ‘길이’는 보통 양수이기 때문에, $\phi$의 치역에 $-\infty$와 $\infty$가 동시에 포함되어 있는 경우는 제외합니다. 또한 $\phi$의 치역이 $\lbrace \infty\rbrace $이거나 $\lbrace -\infty\rbrace $인 경우도 생각하지 않습니다.
+우리는 ‘길이’ 함수를 정의하고자 합니다. ‘길이’는 보통 양수이기 때문에, $\phi$의 치역에 $-\infty$와 $\infty$가 동시에 포함되어 있는 경우는 제외합니다. 또한 $\phi$의 치역이 $\lbrace \infty\rbrace$이거나 $\lbrace -\infty\rbrace$인 경우도 생각하지 않습니다.
 
 따라서, $\phi(A) \in \mathbb{R}$ 인 $A \in \mathcal{R}$이 존재한다고 가정할 수 있습니다. 이 사실은 양변에서 $\phi(A)$를 cancel 할 때 사용됩니다.
 
@@ -204,4 +204,3 @@ $$\lim_{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_{n=1}^\infty A_n \right
 [^3]: 확률의 덧셈정리와 유사합니다. 확률론 또한 measure theory와 관련이 깊습니다.
 
 [^4]: 무한하지 않다는 조건이 있어야 이항이 가능합니다.
-

--- a/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-11-algebra-of-sets.md
@@ -63,19 +63,19 @@ Ring과 유사하지만 살짝 더 좋은 성질을 가진 구조를 가지고 �
 
 조금만 더 확장해서 countable한 연산에 대해서도 허용하고 싶습니다.
 
-**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_{n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
+**정의.** ($\sigma$-ring) $\mathcal{R}$이 ring일 때, $A_n \in \mathcal{R}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{R}$ 이 성립하면 $\mathcal{R}$을 **$\sigma$-ring**이라 한다.
 
 Countable한 합집합을 해도 닫혀 있다는 뜻입니다. 조금 생각해보면 마찬가지로 교집합에 대해서도 성립함을 알 수 있습니다.
 
 **참고.** 다음 성질
 
-$$\bigcap_{n=1}^\infty A_n = A_1 \setminus\bigcup_{n=1}^\infty (A_1 \setminus A_n)$$
+$$\bigcap_ {n=1}^\infty A_n = A_1 \setminus\bigcup_ {n=1}^\infty (A_1 \setminus A_n)$$
 
-을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap_{n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
+을 이용하면 $\mathcal{R}$이 $\sigma$-ring이고 $A_n \in \mathcal{R}$ 일 때 $\displaystyle\bigcap_ {n=1}^\infty A_n \in \mathcal{R}$ 임을 알 수 있다.
 
 마찬가지로 algebra도 정의할 수 있습니다.
 
-**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_{n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
+**정의.** ($\sigma$-algebra) $\mathcal{F}$가 algebra on $X$일 때, $A_n \in \mathcal{F}$ ($n = 1, 2, \dots$) 에 대하여 $\displaystyle\bigcup_ {n=1}^\infty A_n \in \mathcal{F}$ 가 성립하면 $\mathcal{F}$를 **$\sigma$-algebra**라 한다.
 
 $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집합을 해도 닫혀 있습니다.
 
@@ -101,9 +101,9 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 2. 쌍마다 서로소인 집합 $A_i \in \mathcal{R}$ 에 대하여
 
-	$$\phi\left( \bigcup_{i=1}^\infty A_i \right) = \sum_{i=1}^\infty \phi(A_i)$$
+	$$\phi\left( \bigcup_ {i=1}^\infty A_i \right) = \sum_ {i=1}^\infty \phi(A_i)$$
 
-	이고 $\displaystyle\bigcup_{i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
+	이고 $\displaystyle\bigcup_ {i=1}^\infty A_i \in \mathcal{R}$ 이면[^1] $\phi$는 **countably additive** ($\sigma$-additive) 하다.
 
 이제 ‘길이’의 개념을 나타내는 함수를 정의합니다. 이 함수는 측도(measure)라고 합니다.
 
@@ -115,7 +115,7 @@ $\sigma$-algebra는 당연히 $\sigma$-ring이기 때문에 countable한 교집�
 
 1. $\phi$가 additive이면 쌍마다 서로소인 $A_i \in \mathcal{R}$ 에 대하여 다음이 성립한다.
 
-	$$\phi\left( \bigcup_{i=1}^n A_i \right) = \sum_{i=1}^n \phi(A_i).$$
+	$$\phi\left( \bigcup_ {i=1}^n A_i \right) = \sum_ {i=1}^n \phi(A_i).$$
 
 	이 성질을 *finite additivity*라 부르고, $\phi$는 *finitely additive*하다고 한다.
 
@@ -127,7 +127,7 @@ $\phi(A) \in \mathbb{R}$ 인 $A \in \mathcal{R}$이 존재한다는 가정을 �
 
 1. $\mu$가 **finite** 하다. $\iff$모든 $X \in \mathcal{F}$ 에 대하여 $\mu(X) < \infty$ 이다.
 
-2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup_{i=1}^\infty F_i = X$ 이다.
+2. $\mu$가 **$\sigma$-finite** 하다. $\iff$집합열 $F_1 \subseteq F_2 \subseteq\cdots$ 가 존재하여 $\mu(F_i) < \infty$ 이고 $\displaystyle\bigcup_ {i=1}^\infty F_i = X$ 이다.
 
 ## Basic Properties of Set Functions
 
@@ -157,7 +157,7 @@ $\phi$가 set function이라 하자.
 
 	가 성립한다. 귀납법을 적용하면, 모든 $A_i \in \mathcal{R}$에 대하여
 
-	$$\phi\left( \bigcup_{n=1}^m A_n \right) \leq \sum_{n=1}^m \phi(A_n)$$
+	$$\phi\left( \bigcup_ {n=1}^m A_n \right) \leq \sum_ {n=1}^m \phi(A_n)$$
 
 	가 성립한다. 이 때 $A_i$가 반드시 쌍마다 서로소일 필요는 없다. 이 성질을 *finite subadditivity*라 한다.
 
@@ -165,29 +165,29 @@ $\phi$가 set function이라 하자.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \subseteq A_2 \subseteq\cdots$ 이면
 
-$$\lim_{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup_{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
 
 이 성립한다.
 
-**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A_{n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
+**증명.** $B_1 = A_1$, $n \geq 2$ 에 대해 $B_n = A_n \setminus A_ {n-1}$ 로 두자. $B_n$은 쌍마다 서로소임이 자명하다. 따라서,
 
-$$\mu(A_n) = \mu\left( \bigcup_{k=1}^n B_k \right) = \sum_{k=1}^n \mu(B_k)$$
+$$\mu(A_n) = \mu\left( \bigcup_ {k=1}^n B_k \right) = \sum_ {k=1}^n \mu(B_k)$$
 
 이고, measure의 countable additivity를 이용하여
 
-$$\lim_{n\rightarrow\infty} \mu(A_n) = \lim_{n\rightarrow\infty} \sum_{k=1}^n \mu(B_k) = \sum_{n=1}^\infty \mu(B_n) = \mu\left( \bigcup_{n=1}^{\infty} B_n \right) = \mu\left( \bigcup_{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \lim_ {n\rightarrow\infty} \sum_ {k=1}^n \mu(B_k) = \sum_ {n=1}^\infty \mu(B_n) = \mu\left( \bigcup_ {n=1}^{\infty} B_n \right) = \mu\left( \bigcup_ {n=1}^\infty A_n \right)$$
 
-임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup_{n=1}^\infty A_n = \bigcup_{n=1}^\infty B_n$ 임을 이용한다.
+임을 알 수 있다. 마지막 등호에서는 $\displaystyle\bigcup_ {n=1}^\infty A_n = \bigcup_ {n=1}^\infty B_n$ 임을 이용한다.
 
 왠지 위 조건을 뒤집어서 $A_1 \supseteq A_2 \supseteq \cdots$ 인 경우 교집합에 대해서도 성립하면 좋을 것 같습니다.
 
-$$\lim_{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_{n=1}^\infty A_n \right).$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right).$$
 
 하지만 안타깝게도 조건이 부족합니다. $\mu(A_1) < \infty$ 라는 추가 조건이 필요합니다. 반례는 $A_n = [n, \infty)$를 생각해보면 됩니다. 정리의 정확한 서술은 다음과 같습니다. 증명은 연습문제로 남깁니다.
 
 **정리.** $\mu$가 $\sigma$-algebra $\mathcal{F}$의 measure라 하자. $A_n \in \mathcal{F}$ 에 대하여 $A_1 \supseteq A_2 \supseteq \cdots$ 이고 $\mu(A_1) < \infty$ 이면
 
-$$\lim_{n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_{n=1}^\infty A_n \right)$$
+$$\lim_ {n\rightarrow\infty} \mu(A_n) = \mu\left( \bigcap_ {n=1}^\infty A_n \right)$$
 
 이 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
@@ -169,7 +169,7 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 **증명.** $\mathfrak{M}(\mu)$가 $\sigma$-algebra이고 $\mu^\ast$가 $\mathfrak{M}(\mu)$에서 countably additive임을 보이면 충분하다.
 
-(Step 0) *$\mathfrak{M} _ F(\mu)$는 ring이다.*
+**(Step 0)** *$\mathfrak{M} _ F(\mu)$는 ring이다.*
 
 $A, B \in \mathfrak{M} _ F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
 

--- a/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
@@ -19,7 +19,7 @@ image:
 
 **정의.** ($\mathbb{R}^p$의 구간) $a_i, b_i \in \mathbb{R}$, $a_i \leq b_i$ 라 하자. $I_i$가 $\mathbb{R}$의 구간이라고 할 때, $\mathbb{R}^p$의 구간은
 
-$$\prod _{i=1}^p I_i = I_1 \times \cdots \times I_p$$
+$$\prod_ {i=1}^p I_i = I_1 \times \cdots \times I_p$$
 
 와 같이 정의한다.
 
@@ -39,15 +39,15 @@ Elementary set의 모임에서 집합의 연산을 정의할 수 있을 것입�
 
 구간의 길이를 재는 방법은 아주 잘 알고 있습니다. 유한개 구간의 합집합인 elementary set에서도 쉽게 잴 수 있습니다. 이제 길이 함수 $m: \Sigma \rightarrow[0, \infty)$ 을 정의하겠습니다. 아직 measure는 아닙니다.
 
-**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod _{i=1}^p I_i$ 에 대하여,
+**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod_ {i=1}^p I_i$ 에 대하여,
 
-$$m(I) = \prod _{i=1}^p (b_i - a_i)$$
+$$m(I) = \prod_ {i=1}^p (b_i - a_i)$$
 
 로 정의한다.
 
-**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup _{i=1}^n I_i$ 에 대하여
+**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup_ {i=1}^n I_i$ 에 대하여
 
-$$m(A) = \sum _{i=1}^n m(I_i)$$
+$$m(A) = \sum_ {i=1}^n m(I_i)$$
 
 로 정의한다.
 
@@ -71,7 +71,7 @@ $\mathbb{R}, \mathbb{R}^2, \mathbb{R}^3$에서 생각해보면 $m$은 곧 길이
 
 **정의.** (Outer Measure) $E \in \mathcal{P}(\mathbb{R}^p)$ 의 **outer measure** $\mu^\ast: \mathcal{P}(\mathbb{R}^p) \rightarrow[0, \infty]$ 는
 
-$$\mu^\ast(E) = \inf \left\lbrace \sum _{n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup _{n=1}^\infty A_n\right\rbrace.$$
+$$\mu^\ast(E) = \inf \left\lbrace \sum_ {n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_ {n=1}^\infty A_n\right\rbrace.$$
 
 로 정의한다.
 
@@ -89,7 +89,7 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 2. Countable subadditivity가 성립한다.
 
-	$$\mu^\ast\left( \bigcup _{n=1}^\infty E_n \right) \leq \sum _{n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
+	$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
 
 **증명.**
 
@@ -97,23 +97,23 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 $$\mu^\ast(A) \leq \mu(G) \leq \mu(A) + \epsilon$$
 
-이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup _{n=1}^\infty A_n$ 이고
+이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup_ {n=1}^\infty A_n$ 이고
 
-$$\sum _{n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
+$$\sum_ {n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
 
-이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup _{i=1}^N A _{i}$ 가 성립한다.
+이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup_ {i=1}^N A_ {i}$ 가 성립한다.
 
 따라서
 
-$$\mu(A) \leq \mu(F) + \epsilon \leq \sum _{i=1}^N \mu(A_i) \leq \sum _{i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
+$$\mu(A) \leq \mu(F) + \epsilon \leq \sum_ {i=1}^N \mu(A_i) \leq \sum_ {i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
 
 이제 $\epsilon \rightarrow 0$ 로 두면 $\mu(A) = \mu^\ast(A)$ 를 얻는다.
 
-\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A _{n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup _{k=1}^\infty A _{n, k}$ 이고 $\displaystyle\sum _{k=1}^\infty \mu(A _{n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
+\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A_ {n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup_ {k=1}^\infty A_ {n, k}$ 이고 $\displaystyle\sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
 
 $\mu^\ast$는 하한(infimum)으로 정의되었기 때문에,
 
-$$\mu^\ast\left( \bigcup _{n=1}^\infty E_n \right) \leq \sum _{n=1}^\infty \sum _{k=1}^\infty \mu(A _{n,k}) \leq \sum _{n=1}^\infty \mu^\ast(E_n) + \epsilon$$
+$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \sum_ {n=1}^\infty \mu^\ast(E_n) + \epsilon$$
 
 가 성립하고, $\epsilon \rightarrow 0$ 로 두면 부등식이 성립함을 알 수 있다.
 
@@ -137,11 +137,11 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 	$$\left.\begin{array}{c}d(A_1 \cup A_2, B_1 \cup B_2) \\d(A_1 \cap A_2, B_1 \cap B_2) \\d(A_1 \setminus A_2, B_1 \setminus B_2)\end{array}\right\rbrace\leq d(A_1, B_1) + d(A_2, B_2).$$
 
-**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M}_ F(\mu)$로 표기한다.
+**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M} _ F(\mu)$로 표기한다.
 
 위 정의는 $\mu$라는 set function에 의해 $\mu^\ast (A_n \mathop{\mathrm{\triangle}}A) \rightarrow 0$ 이 되는 elementary set $A_n$이 존재한다는 의미입니다.
 
-**정의.** ($\mu$-measurable) $A_n \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup _{n=1}^\infty A_n$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
+**정의.** ($\mu$-measurable) $A_n \in \mathfrak{M} _ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
 
 **참고.** $\mu^\ast(A) = d(A, \varnothing) \leq d(A, B) + \mu^\ast(B)$.
 
@@ -149,7 +149,7 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 $$\lvert \mu^\ast(A) - \mu^\ast(B) \rvert \leq d(A, B).$$
 
-**따름정리.** $A \in \mathfrak{M}_ F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A \in \mathfrak{M} _ F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $A_n \in \Sigma$ 가 존재하여 $A_n \rightarrow A$ 이고, $N \in \mathbb{N}$ 이 존재하여
 
@@ -157,7 +157,7 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 이다.
 
-**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M}_ F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M} _ F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $\mu^\ast(A)$, $\mu^\ast(A_n)$가 유한하므로, $n \rightarrow\infty$ 일 때 $\lvert \mu^\ast(A_n) - \mu^\ast(A) \rvert \leq d(A_n, A) \rightarrow 0$ 이다.
 
@@ -169,15 +169,15 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 **증명.** $\mathfrak{M}(\mu)$가 $\sigma$-algebra이고 $\mu^\ast$가 $\mathfrak{M}(\mu)$에서 countably additive임을 보이면 충분하다.
 
-(Step 0) *$\mathfrak{M}_ F(\mu)$는 ring이다.*
+(Step 0) *$\mathfrak{M} _ F(\mu)$는 ring이다.*
 
-$A, B \in \mathfrak{M}_ F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
+$A, B \in \mathfrak{M} _ F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
 
 $$\left.\begin{array}{c}d(A_n \cup B_n, A \cup B) \\ d(A_n \cap B_n, A \cap B) \\ d(A_n \setminus B_n, A \setminus B)\end{array}\right\rbrace\leq d(A_n, A) + d(B_n, B) \rightarrow 0$$
 
-이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M}_ F(\mu)$는 ring이다.
+이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M} _ F(\mu)$는 ring이다.
 
-**(Step 1)** *$\mu^\ast$는 $\mathfrak{M}_ F(\mu)$ 위에서 additive이다*.
+**(Step 1)** *$\mu^\ast$는 $\mathfrak{M} _ F(\mu)$ 위에서 additive이다*.
 
 $\Sigma$ 위에서는 $\mu = \mu^\ast$ 이므로, 위 따름정리에 의해
 
@@ -189,63 +189,63 @@ $$\mu^\ast(A) + \mu^\ast(B) = \mu^\ast(A\cup B) + \mu^\ast(A \cap B)$$
 
 를 얻는다. $A \cap B = \varnothing$ 라는 조건이 추가되면 $\mu^\ast$가 additive임을 알 수 있다.
 
-**(Step 2)** *$\mathfrak{M}_ F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
+**(Step 2)** *$\mathfrak{M} _ F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
 
-**Claim**. 쌍마다 서로소인 $\mathfrak{M}_ F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
+**Claim**. 쌍마다 서로소인 $\mathfrak{M} _ F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
 
-**증명.** $A_n' \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
+**증명.** $A_n' \in \mathfrak{M} _ F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
 
-> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A _{n-1}')$
+> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A_ {n-1}')$
 
-와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M}_ F(\mu)$ 임을 알 수 있다.
+와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M} _ F(\mu)$ 임을 알 수 있다.
 
-위 사실을 이용하여 $A_n \in \mathfrak{M}_  F(\mu)$ 에 대하여 $A = \displaystyle\bigcup _{n=1}^\infty A_n$ 으로 두자.
+위 사실을 이용하여 $A_n \in \mathfrak{M} _  F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 으로 두자.
 
-1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum _{n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
+1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum_ {n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
 
-2. Step 1에 의해 $\displaystyle\bigcup _{n=1}^k A_n \subseteq A$, $\displaystyle\sum _{n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum _{n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
+2. Step 1에 의해 $\displaystyle\bigcup_ {n=1}^k A_n \subseteq A$, $\displaystyle\sum_ {n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum_ {n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
 
-따라서 $\displaystyle\mu^\ast(A) = \sum _{n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
+따라서 $\displaystyle\mu^\ast(A) = \sum_ {n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
 
-이제 $B_n =\displaystyle\bigcup _{k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum _{n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
+이제 $B_n =\displaystyle\bigcup_ {k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum_ {n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
 
-$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup _{k=n+1}^\infty A_k \right) = \sum _{k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
+$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup_ {k=n+1}^\infty A_k \right) = \sum_ {k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
 
 임을 알 수 있다.
 
-$B_n \in \mathfrak{M}_ F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M}_ F(\mu)$ 라는 결론을 내릴 수 있다.
+$B_n \in \mathfrak{M} _ F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M} _ F(\mu)$ 라는 결론을 내릴 수 있다.
 
 **(Step 3)** *$\mu^\ast$는 $\mathfrak{M}(\mu)$ 위에서 countably additive이다.*
 
 $A_n \in \mathfrak{M}(\mu)$ 가 $A \in \mathfrak{M}(\mu)$ 의 분할이라 하자. 적당한 $m \in \mathbb{N}$ 에 대하여 $\mu^\ast(A_m) = \infty$ 이면
 
-$$\mu^\ast\left( \bigcup _{n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum _{n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
 
 이므로 countable additivity가 성립한다.
 
-이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M}_ F(\mu)$ 이고
+이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M} _ F(\mu)$ 이고
 
-$$\mu^\ast(A) = \mu^\ast\left( \bigcup _{n=1}^\infty A_n \right) = \sum _{n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast(A) = \mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
 
 가 성립한다.
 
 **(Step 4)** *$\mathfrak{M}(\mu)$는 $\sigma$-ring이다.*
 
-$A_n \in \mathfrak{M}(\mu)$ 이면 $B _{n, k} \in \mathfrak{M}_ F(\mu)$ 가 존재하여 $\displaystyle A_n = \bigcup_k B _{n,k}$ 이다. 그러면
+$A_n \in \mathfrak{M}(\mu)$ 이면 $B_ {n, k} \in \mathfrak{M} _ F(\mu)$ 가 존재하여 $\displaystyle A_n = \bigcup_k B_ {n,k}$ 이다. 그러면
 
-$$\bigcup_n A_n = \bigcup _{n, k} B _{n, k} \in \mathfrak{M}(\mu)$$
+$$\bigcup_n A_n = \bigcup_ {n, k} B_ {n, k} \in \mathfrak{M}(\mu)$$
 
 이다.
 
-$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M}_ F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
+$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M} _ F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
 
-$$A \setminus B = \bigcup _{n=1}^\infty \left( A_n \setminus B \right) = \bigcup _{n=1}^\infty (A_n\setminus(A_n\cap B))$$
+$$A \setminus B = \bigcup_ {n=1}^\infty \left( A_n \setminus B \right) = \bigcup_ {n=1}^\infty (A_n\setminus(A_n\cap B))$$
 
-임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M}_ F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
+임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M} _ F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
 
-$$A_n \cap B = \bigcup _{k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
+$$A_n \cap B = \bigcup_ {k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
-이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M}_ F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M}_ F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
+이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M} _ F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M} _ F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
 
 따라서 $\mathfrak{M}(\mu)$는 $\sigma$-ring이고 $\sigma$-algebra이다.
 
@@ -257,6 +257,6 @@ $$A_n \cap B = \bigcup _{k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
 [^2]: $A$가 $\mu$-measurable인데 $\mu^\ast(A) < \infty$이면 $A$는 finitely $\mu$-measurable이다.
 
-[^3]: $A$가 countable union of sets in $\mathfrak{M}_ F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
+[^3]: $A$가 countable union of sets in $\mathfrak{M} _ F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
 
-[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M}_ F(\mu)$의 원소입니다.
+[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M} _ F(\mu)$의 원소입니다.

--- a/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
@@ -19,7 +19,7 @@ image:
 
 **정의.** ($\mathbb{R}^p$의 구간) $a_i, b_i \in \mathbb{R}$, $a_i \leq b_i$ 라 하자. $I_i$가 $\mathbb{R}$의 구간이라고 할 때, $\mathbb{R}^p$의 구간은
 
-$$\prod_{i=1}^p I_i = I_1 \times \cdots \times I_p$$
+$$\prod_ {i=1}^p I_i = I_1 \times \cdots \times I_p$$
 
 와 같이 정의한다.
 
@@ -39,15 +39,15 @@ Elementary set의 모임에서 집합의 연산을 정의할 수 있을 것입�
 
 구간의 길이를 재는 방법은 아주 잘 알고 있습니다. 유한개 구간의 합집합인 elementary set에서도 쉽게 잴 수 있습니다. 이제 길이 함수 $m: \Sigma \rightarrow[0, \infty)$ 을 정의하겠습니다. 아직 measure는 아닙니다.
 
-**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod_{i=1}^p I_i$ 에 대하여,
+**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod_ {i=1}^p I_i$ 에 대하여,
 
-$$m(I) = \prod_{i=1}^p (b_i - a_i)$$
+$$m(I) = \prod_ {i=1}^p (b_i - a_i)$$
 
 로 정의한다.
 
-**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup_{i=1}^n I_i$ 에 대하여
+**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup_ {i=1}^n I_i$ 에 대하여
 
-$$m(A) = \sum_{i=1}^n m(I_i)$$
+$$m(A) = \sum_ {i=1}^n m(I_i)$$
 
 로 정의한다.
 
@@ -71,7 +71,7 @@ $\mathbb{R}, \mathbb{R}^2, \mathbb{R}^3$에서 생각해보면 $m$은 곧 길이
 
 **정의.** (Outer Measure) $E \in \mathcal{P}(\mathbb{R}^p)$ 의 **outer measure** $\mu^\ast: \mathcal{P}(\mathbb{R}^p) \rightarrow[0, \infty]$ 는
 
-$$\mu^\ast(E) = \inf \left\lbrace \sum_{n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_{n=1}^\infty A_n\right\rbrace.$$
+$$\mu^\ast(E) = \inf \left\lbrace \sum_ {n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_ {n=1}^\infty A_n\right\rbrace.$$
 
 로 정의한다.
 
@@ -89,7 +89,7 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 2. Countable subadditivity가 성립한다.
 
-	$$\mu^\ast\left( \bigcup_{n=1}^\infty E_n \right) \leq \sum_{n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
+	$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
 
 **증명.**
 
@@ -97,23 +97,23 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 $$\mu^\ast(A) \leq \mu(G) \leq \mu(A) + \epsilon$$
 
-이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup_{n=1}^\infty A_n$ 이고
+이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup_ {n=1}^\infty A_n$ 이고
 
-$$\sum_{n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
+$$\sum_ {n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
 
-이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup_{i=1}^N A_{i}$ 가 성립한다.
+이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup_ {i=1}^N A_ {i}$ 가 성립한다.
 
 따라서
 
-$$\mu(A) \leq \mu(F) + \epsilon \leq \sum_{i=1}^N \mu(A_i) \leq \sum_{i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
+$$\mu(A) \leq \mu(F) + \epsilon \leq \sum_ {i=1}^N \mu(A_i) \leq \sum_ {i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
 
 이제 $\epsilon \rightarrow 0$ 로 두면 $\mu(A) = \mu^\ast(A)$ 를 얻는다.
 
-\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A_{n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup_{k=1}^\infty A_{n, k}$ 이고 $\displaystyle\sum_{k=1}^\infty \mu(A_{n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
+\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A_ {n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup_ {k=1}^\infty A_ {n, k}$ 이고 $\displaystyle\sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
 
 $\mu^\ast$는 하한(infimum)으로 정의되었기 때문에,
 
-$$\mu^\ast\left( \bigcup_{n=1}^\infty E_n \right) \leq \sum_{n=1}^\infty \sum_{k=1}^\infty \mu(A_{n,k}) \leq \sum_{n=1}^\infty \mu^\ast(E_n) + \epsilon$$
+$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \sum_ {n=1}^\infty \mu^\ast(E_n) + \epsilon$$
 
 가 성립하고, $\epsilon \rightarrow 0$ 로 두면 부등식이 성립함을 알 수 있다.
 
@@ -137,11 +137,11 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 	$$\left.\begin{array}{c}d(A_1 \cup A_2, B_1 \cup B_2) \\d(A_1 \cap A_2, B_1 \cap B_2) \\d(A_1 \setminus A_2, B_1 \setminus B_2)\end{array}\right\rbrace\leq d(A_1, B_1) + d(A_2, B_2).$$
 
-**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M}_F(\mu)$로 표기한다.
+**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M} _F(\mu)$로 표기한다.
 
 위 정의는 $\mu$라는 set function에 의해 $\mu^\ast (A_n \mathop{\mathrm{\triangle}}A) \rightarrow 0$ 이 되는 elementary set $A_n$이 존재한다는 의미입니다.
 
-**정의.** ($\mu$-measurable) $$A_n \in \mathfrak{M}_F(\mu)$$ 에 대하여 $$A = \displaystyle\bigcup_{n=1}^\infty A_n$$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
+**정의.** ($\mu$-measurable) $A_n \in \mathfrak{M} _F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
 
 **참고.** $\mu^\ast(A) = d(A, \varnothing) \leq d(A, B) + \mu^\ast(B)$.
 
@@ -149,7 +149,7 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 $$\lvert \mu^\ast(A) - \mu^\ast(B) \rvert \leq d(A, B).$$
 
-**따름정리.** $A \in \mathfrak{M}_F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A \in \mathfrak{M} _F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $A_n \in \Sigma$ 가 존재하여 $A_n \rightarrow A$ 이고, $N \in \mathbb{N}$ 이 존재하여
 
@@ -157,7 +157,7 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 이다.
 
-**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M}_F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M} _F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $\mu^\ast(A)$, $\mu^\ast(A_n)$가 유한하므로, $n \rightarrow\infty$ 일 때 $\lvert \mu^\ast(A_n) - \mu^\ast(A) \rvert \leq d(A_n, A) \rightarrow 0$ 이다.
 
@@ -169,15 +169,15 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 **증명.** $\mathfrak{M}(\mu)$가 $\sigma$-algebra이고 $\mu^\ast$가 $\mathfrak{M}(\mu)$에서 countably additive임을 보이면 충분하다.
 
-(Step 0) *$\mathfrak{M}_F(\mu)$는 ring이다.*
+(Step 0) *$\mathfrak{M} _F(\mu)$는 ring이다.*
 
-$A, B \in \mathfrak{M}_F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
+$A, B \in \mathfrak{M} _F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
 
 $$\left.\begin{array}{c}d(A_n \cup B_n, A \cup B) \\ d(A_n \cap B_n, A \cap B) \\ d(A_n \setminus B_n, A \setminus B)\end{array}\right\rbrace\leq d(A_n, A) + d(B_n, B) \rightarrow 0$$
 
-이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M}_F(\mu)$는 ring이다.
+이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M} _F(\mu)$는 ring이다.
 
-**(Step 1)** *$\mu^\ast$는 $\mathfrak{M}_F(\mu)$ 위에서 additive이다*.
+**(Step 1)** *$\mu^\ast$는 $\mathfrak{M} _F(\mu)$ 위에서 additive이다*.
 
 $\Sigma$ 위에서는 $\mu = \mu^\ast$ 이므로, 위 따름정리에 의해
 
@@ -189,63 +189,63 @@ $$\mu^\ast(A) + \mu^\ast(B) = \mu^\ast(A\cup B) + \mu^\ast(A \cap B)$$
 
 를 얻는다. $A \cap B = \varnothing$ 라는 조건이 추가되면 $\mu^\ast$가 additive임을 알 수 있다.
 
-**(Step 2)** *$\mathfrak{M}_F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
+**(Step 2)** *$\mathfrak{M} _F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
 
-**Claim**. 쌍마다 서로소인 $\mathfrak{M}_F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
+**Claim**. 쌍마다 서로소인 $\mathfrak{M} _F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
 
-**증명.** $A_n' \in \mathfrak{M}_F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
+**증명.** $A_n' \in \mathfrak{M} _F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
 
-> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A_{n-1}')$
+> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A_ {n-1}')$
 
-와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M}_F(\mu)$ 임을 알 수 있다.
+와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M} _F(\mu)$ 임을 알 수 있다.
 
-위 사실을 이용하여 $A_n \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_{n=1}^\infty A_n$ 으로 두자.
+위 사실을 이용하여 $A_n \in \mathfrak{M} _ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 으로 두자.
 
-1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum_{n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
+1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum_ {n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
 
-2. Step 1에 의해 $\displaystyle\bigcup_{n=1}^k A_n \subseteq A$, $\displaystyle\sum_{n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum_{n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
+2. Step 1에 의해 $\displaystyle\bigcup_ {n=1}^k A_n \subseteq A$, $\displaystyle\sum_ {n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum_ {n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
 
-따라서 $\displaystyle\mu^\ast(A) = \sum_{n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
+따라서 $\displaystyle\mu^\ast(A) = \sum_ {n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
 
-이제 $B_n =\displaystyle\bigcup_{k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum_{n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
+이제 $B_n =\displaystyle\bigcup_ {k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum_ {n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
 
-$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup_{k=n+1}^\infty A_k \right) = \sum_{k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
+$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup_ {k=n+1}^\infty A_k \right) = \sum_ {k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
 
 임을 알 수 있다.
 
-$B_n \in \mathfrak{M}_F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M}_F(\mu)$ 라는 결론을 내릴 수 있다.
+$B_n \in \mathfrak{M} _F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M} _F(\mu)$ 라는 결론을 내릴 수 있다.
 
 **(Step 3)** *$\mu^\ast$는 $\mathfrak{M}(\mu)$ 위에서 countably additive이다.*
 
 $A_n \in \mathfrak{M}(\mu)$ 가 $A \in \mathfrak{M}(\mu)$ 의 분할이라 하자. 적당한 $m \in \mathbb{N}$ 에 대하여 $\mu^\ast(A_m) = \infty$ 이면
 
-$$\mu^\ast\left( \bigcup_{n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum_{n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
 
 이므로 countable additivity가 성립한다.
 
-이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M}_F(\mu)$ 이고
+이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M} _F(\mu)$ 이고
 
-$$\mu^\ast(A) = \mu^\ast\left( \bigcup_{n=1}^\infty A_n \right) = \sum_{n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast(A) = \mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
 
 가 성립한다.
 
 **(Step 4)** *$\mathfrak{M}(\mu)$는 $\sigma$-ring이다.*
 
-$A_n \in \mathfrak{M}(\mu)$ 이면 $$B_{n, k} \in \mathfrak{M}_F(\mu)$$ 가 존재하여 $$\displaystyle A_n = \bigcup_k B_{n,k}$$ 이다. 그러면
+$A_n \in \mathfrak{M}(\mu)$ 이면 $B_ {n, k} \in \mathfrak{M} _F(\mu)$ 가 존재하여 $\displaystyle A_n = \bigcup_k B_ {n,k}$ 이다. 그러면
 
-$$\bigcup_n A_n = \bigcup_{n, k} B_{n, k} \in \mathfrak{M}(\mu)$$
+$$\bigcup_n A_n = \bigcup_ {n, k} B_ {n, k} \in \mathfrak{M}(\mu)$$
 
 이다.
 
-$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M}_F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
+$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M} _F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
 
-$$A \setminus B = \bigcup_{n=1}^\infty \left( A_n \setminus B \right) = \bigcup_{n=1}^\infty (A_n\setminus(A_n\cap B))$$
+$$A \setminus B = \bigcup_ {n=1}^\infty \left( A_n \setminus B \right) = \bigcup_ {n=1}^\infty (A_n\setminus(A_n\cap B))$$
 
-임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M}_F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
+임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M} _F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
 
-$$A_n \cap B = \bigcup_{k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
+$$A_n \cap B = \bigcup_ {k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
-이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M}_F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M}_F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
+이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M} _F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M} _F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
 
 따라서 $\mathfrak{M}(\mu)$는 $\sigma$-ring이고 $\sigma$-algebra이다.
 
@@ -257,6 +257,6 @@ $$A_n \cap B = \bigcup_{k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
 [^2]: $A$가 $\mu$-measurable인데 $\mu^\ast(A) < \infty$이면 $A$는 finitely $\mu$-measurable이다.
 
-[^3]: $A$가 countable union of sets in $\mathfrak{M}_F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
+[^3]: $A$가 countable union of sets in $\mathfrak{M} _F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
 
-[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M}_F(\mu)$의 원소입니다.
+[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M} _F(\mu)$의 원소입니다.

--- a/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
@@ -19,7 +19,7 @@ image:
 
 **정의.** ($\mathbb{R}^p$의 구간) $a_i, b_i \in \mathbb{R}$, $a_i \leq b_i$ 라 하자. $I_i$가 $\mathbb{R}$의 구간이라고 할 때, $\mathbb{R}^p$의 구간은
 
-$$\prod_ {i=1}^p I_i = I_1 \times \cdots \times I_p$$
+$$\prod _{i=1}^p I_i = I_1 \times \cdots \times I_p$$
 
 와 같이 정의한다.
 
@@ -39,15 +39,15 @@ Elementary set의 모임에서 집합의 연산을 정의할 수 있을 것입�
 
 구간의 길이를 재는 방법은 아주 잘 알고 있습니다. 유한개 구간의 합집합인 elementary set에서도 쉽게 잴 수 있습니다. 이제 길이 함수 $m: \Sigma \rightarrow[0, \infty)$ 을 정의하겠습니다. 아직 measure는 아닙니다.
 
-**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod_ {i=1}^p I_i$ 에 대하여,
+**정의.** $a_i, b_i \in \mathbb{R}$ 가 구간 $I_i$의 양 끝점이라 하자. $\mathbb{R}^p$의 구간 $I = \displaystyle\prod _{i=1}^p I_i$ 에 대하여,
 
-$$m(I) = \prod_ {i=1}^p (b_i - a_i)$$
+$$m(I) = \prod _{i=1}^p (b_i - a_i)$$
 
 로 정의한다.
 
-**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup_ {i=1}^n I_i$ 에 대하여
+**정의.** $I_i$가 쌍마다 서로소인 $\mathbb{R}^p$의 구간이라 하자. $A = \displaystyle\bigcup _{i=1}^n I_i$ 에 대하여
 
-$$m(A) = \sum_ {i=1}^n m(I_i)$$
+$$m(A) = \sum _{i=1}^n m(I_i)$$
 
 로 정의한다.
 
@@ -71,7 +71,7 @@ $\mathbb{R}, \mathbb{R}^2, \mathbb{R}^3$에서 생각해보면 $m$은 곧 길이
 
 **정의.** (Outer Measure) $E \in \mathcal{P}(\mathbb{R}^p)$ 의 **outer measure** $\mu^\ast: \mathcal{P}(\mathbb{R}^p) \rightarrow[0, \infty]$ 는
 
-$$\mu^\ast(E) = \inf \left\lbrace \sum_ {n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_ {n=1}^\infty A_n\right\rbrace.$$
+$$\mu^\ast(E) = \inf \left\lbrace \sum _{n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup _{n=1}^\infty A_n\right\rbrace.$$
 
 로 정의한다.
 
@@ -89,7 +89,7 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 2. Countable subadditivity가 성립한다.
 
-	$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
+	$$\mu^\ast\left( \bigcup _{n=1}^\infty E_n \right) \leq \sum _{n=1}^\infty \mu^\ast(E_n), \quad (\forall E_n \in \mathcal{P}(\mathbb{R}^p))$$
 
 **증명.**
 
@@ -97,23 +97,23 @@ Outer measure라 부르는 이유는 $E$의 바깥에서 길이를 재서 근사
 
 $$\mu^\ast(A) \leq \mu(G) \leq \mu(A) + \epsilon$$
 
-이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup_ {n=1}^\infty A_n$ 이고
+이다. $\mu^\ast$의 정의에 의해 열린집합 $A_n \in \Sigma$ 가 존재하여 $A \subseteq\displaystyle\bigcup _{n=1}^\infty A_n$ 이고
 
-$$\sum_ {n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
+$$\sum _{n=1}^\infty \mu(A_n) \leq \mu^\ast(A) + \epsilon$$
 
-이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup_ {i=1}^N A_ {i}$ 가 성립한다.
+이다. 마찬가지로 regularity에 의해 닫힌집합 $F \in \Sigma$ 가 존재하여 $F\subseteq A$ 이고 $\mu(A) \leq \mu(F) + \epsilon$ 이다. $F \subseteq\mathbb{R}^p$ 는 유계이고 닫힌집합이므로 compact set이고, finite open cover를 택할 수 있다. 즉, 적당한 $N \in \mathbb{N}$ 에 대하여 $F \subseteq\displaystyle\bigcup _{i=1}^N A _{i}$ 가 성립한다.
 
 따라서
 
-$$\mu(A) \leq \mu(F) + \epsilon \leq \sum_ {i=1}^N \mu(A_i) \leq \sum_ {i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
+$$\mu(A) \leq \mu(F) + \epsilon \leq \sum _{i=1}^N \mu(A_i) \leq \sum _{i=1}^n \mu(A_i) + \epsilon \leq \mu^\ast(A) + 2\epsilon$$
 
 이제 $\epsilon \rightarrow 0$ 로 두면 $\mu(A) = \mu^\ast(A)$ 를 얻는다.
 
-\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A_ {n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup_ {k=1}^\infty A_ {n, k}$ 이고 $\displaystyle\sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
+\(2\) 부등식의 양변이 모두 $\infty$ 이면 증명할 것이 없으므로, 양변이 모두 유한하다고 가정하여 모든 $n\in \mathbb{N}$ 에 대해 $\mu^\ast(E_n) < \infty$ 라 하자. $\epsilon > 0$ 로 두고, 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $A _{n, k} \in \Sigma$ 가 존재하여 $E_n \subseteq\displaystyle\bigcup _{k=1}^\infty A _{n, k}$ 이고 $\displaystyle\sum _{k=1}^\infty \mu(A _{n,k}) \leq \mu^\ast(E_n) + 2^{-n}\epsilon$ 이다.
 
 $\mu^\ast$는 하한(infimum)으로 정의되었기 때문에,
 
-$$\mu^\ast\left( \bigcup_ {n=1}^\infty E_n \right) \leq \sum_ {n=1}^\infty \sum_ {k=1}^\infty \mu(A_ {n,k}) \leq \sum_ {n=1}^\infty \mu^\ast(E_n) + \epsilon$$
+$$\mu^\ast\left( \bigcup _{n=1}^\infty E_n \right) \leq \sum _{n=1}^\infty \sum _{k=1}^\infty \mu(A _{n,k}) \leq \sum _{n=1}^\infty \mu^\ast(E_n) + \epsilon$$
 
 가 성립하고, $\epsilon \rightarrow 0$ 로 두면 부등식이 성립함을 알 수 있다.
 
@@ -137,11 +137,11 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 	$$\left.\begin{array}{c}d(A_1 \cup A_2, B_1 \cup B_2) \\d(A_1 \cap A_2, B_1 \cap B_2) \\d(A_1 \setminus A_2, B_1 \setminus B_2)\end{array}\right\rbrace\leq d(A_1, B_1) + d(A_2, B_2).$$
 
-**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M} _F(\mu)$로 표기한다.
+**정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M}_ F(\mu)$로 표기한다.
 
 위 정의는 $\mu$라는 set function에 의해 $\mu^\ast (A_n \mathop{\mathrm{\triangle}}A) \rightarrow 0$ 이 되는 elementary set $A_n$이 존재한다는 의미입니다.
 
-**정의.** ($\mu$-measurable) $A_n \in \mathfrak{M} _F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
+**정의.** ($\mu$-measurable) $A_n \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup _{n=1}^\infty A_n$ 이면 $A$가 **$\mu$-measurable**이라 한다. 그리고 $\mu$-measurable한 집합의 모임을 $\mathfrak{M}(\mu)$로 표기한다.
 
 **참고.** $\mu^\ast(A) = d(A, \varnothing) \leq d(A, B) + \mu^\ast(B)$.
 
@@ -149,7 +149,7 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 $$\lvert \mu^\ast(A) - \mu^\ast(B) \rvert \leq d(A, B).$$
 
-**따름정리.** $A \in \mathfrak{M} _F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A \in \mathfrak{M}_ F(\mu)$ 이면 $\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $A_n \in \Sigma$ 가 존재하여 $A_n \rightarrow A$ 이고, $N \in \mathbb{N}$ 이 존재하여
 
@@ -157,7 +157,7 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 이다.
 
-**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M} _F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
+**따름정리.** $A_n \rightarrow A$ 이고 $A_n, A \in \mathfrak{M}_ F(\mu)$ 이면 $\mu^\ast(A_n)\rightarrow\mu^\ast(A) < \infty$ 이다.
 
 **증명.** $\mu^\ast(A)$, $\mu^\ast(A_n)$가 유한하므로, $n \rightarrow\infty$ 일 때 $\lvert \mu^\ast(A_n) - \mu^\ast(A) \rvert \leq d(A_n, A) \rightarrow 0$ 이다.
 
@@ -169,15 +169,15 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 **증명.** $\mathfrak{M}(\mu)$가 $\sigma$-algebra이고 $\mu^\ast$가 $\mathfrak{M}(\mu)$에서 countably additive임을 보이면 충분하다.
 
-(Step 0) *$\mathfrak{M} _F(\mu)$는 ring이다.*
+(Step 0) *$\mathfrak{M}_ F(\mu)$는 ring이다.*
 
-$A, B \in \mathfrak{M} _F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
+$A, B \in \mathfrak{M}_ F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
 
 $$\left.\begin{array}{c}d(A_n \cup B_n, A \cup B) \\ d(A_n \cap B_n, A \cap B) \\ d(A_n \setminus B_n, A \setminus B)\end{array}\right\rbrace\leq d(A_n, A) + d(B_n, B) \rightarrow 0$$
 
-이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M} _F(\mu)$는 ring이다.
+이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M}_ F(\mu)$는 ring이다.
 
-**(Step 1)** *$\mu^\ast$는 $\mathfrak{M} _F(\mu)$ 위에서 additive이다*.
+**(Step 1)** *$\mu^\ast$는 $\mathfrak{M}_ F(\mu)$ 위에서 additive이다*.
 
 $\Sigma$ 위에서는 $\mu = \mu^\ast$ 이므로, 위 따름정리에 의해
 
@@ -189,63 +189,63 @@ $$\mu^\ast(A) + \mu^\ast(B) = \mu^\ast(A\cup B) + \mu^\ast(A \cap B)$$
 
 를 얻는다. $A \cap B = \varnothing$ 라는 조건이 추가되면 $\mu^\ast$가 additive임을 알 수 있다.
 
-**(Step 2)** *$\mathfrak{M} _F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
+**(Step 2)** *$\mathfrak{M}_ F(\mu) = \lbrace A \in \mathfrak{M}(\mu) : \mu^\ast(A) < \infty\rbrace$.*[^2]
 
-**Claim**. 쌍마다 서로소인 $\mathfrak{M} _F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
+**Claim**. 쌍마다 서로소인 $\mathfrak{M}_ F(\mu)$의 원소들을 잡아 이들의 합집합으로 $A \in \mathfrak{M}(\mu)$ 를 표현할 수 있다.
 
-**증명.** $A_n' \in \mathfrak{M} _F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
+**증명.** $A_n' \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \bigcup A_n'$ 로 두자.
 
-> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A_ {n-1}')$
+> $A_1 = A_1'$, $n \geq 2$ 이면 $A_n = A_n' \setminus(A_1'\cup \cdots \cup A _{n-1}')$
 
-와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M} _F(\mu)$ 임을 알 수 있다.
+와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M}_ F(\mu)$ 임을 알 수 있다.
 
-위 사실을 이용하여 $A_n \in \mathfrak{M} _ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_ {n=1}^\infty A_n$ 으로 두자.
+위 사실을 이용하여 $A_n \in \mathfrak{M}_  F(\mu)$ 에 대하여 $A = \displaystyle\bigcup _{n=1}^\infty A_n$ 으로 두자.
 
-1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum_ {n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
+1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum _{n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
 
-2. Step 1에 의해 $\displaystyle\bigcup_ {n=1}^k A_n \subseteq A$, $\displaystyle\sum_ {n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum_ {n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
+2. Step 1에 의해 $\displaystyle\bigcup _{n=1}^k A_n \subseteq A$, $\displaystyle\sum _{n=1}^{k} \mu^\ast(A_n) \leq \mu^\ast(A)$ 이다. $k \rightarrow\infty$ 로 두면 $\displaystyle\mu^\ast(A) \geq \sum _{n=1}^\infty \mu^\ast(A_n)$ 임을 알 수 있다.
 
-따라서 $\displaystyle\mu^\ast(A) = \sum_ {n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
+따라서 $\displaystyle\mu^\ast(A) = \sum _{n=1}^\infty \mu^\ast(A_n)$ 이다.[^3] [^4]
 
-이제 $B_n =\displaystyle\bigcup_ {k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum_ {n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
+이제 $B_n =\displaystyle\bigcup _{k=1}^n A_k$ 로 두자. $\mu^\ast(A) < \infty$ 를 가정하면 $\displaystyle\sum _{n=1}^\infty \mu^\ast(A_n)$의 수렴성에 의해
 
-$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup_ {k=n+1}^\infty A_k \right) = \sum_ {k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
+$$\displaystyle d(A, B_n) = \mu^\ast\left( \bigcup _{k=n+1}^\infty A_k \right) = \sum _{k=n+1}^{\infty} \mu^\ast(A_i) \rightarrow 0 \text{ as } n \rightarrow\infty$$
 
 임을 알 수 있다.
 
-$B_n \in \mathfrak{M} _F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M} _F(\mu)$ 라는 결론을 내릴 수 있다.
+$B_n \in \mathfrak{M}_ F(\mu)$ 이므로 $C_n \in \Sigma$ 를 잡아 각 $n \in \mathbb{N}$ 에 대하여 $d(B_n, C_n)$를 임의로 작게 만들 수 있다. 그러면 $d(A, C_n) \leq d(A, B_n) + d(B_n, C_n)$ 이므로 충분히 큰 $n$에 대하여 $d(A, C_n)$도 임의로 작게 만들 수 있다. 따라서 $C_n \rightarrow A$ 임을 알 수 있고 $A \in \mathfrak{M}_ F(\mu)$ 라는 결론을 내릴 수 있다.
 
 **(Step 3)** *$\mu^\ast$는 $\mathfrak{M}(\mu)$ 위에서 countably additive이다.*
 
 $A_n \in \mathfrak{M}(\mu)$ 가 $A \in \mathfrak{M}(\mu)$ 의 분할이라 하자. 적당한 $m \in \mathbb{N}$ 에 대하여 $\mu^\ast(A_m) = \infty$ 이면
 
-$$\mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast\left( \bigcup _{n=1}^\infty A_n \right) \geq \mu^\ast(A_m) = \infty = \sum _{n=1}^\infty \mu^\ast(A_n)$$
 
 이므로 countable additivity가 성립한다.
 
-이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M} _F(\mu)$ 이고
+이제 모든 $n\in \mathbb{N}$ 에 대하여 $\mu^\ast(A_n) < \infty$ 이면, Step 2에 의해 $A_n \in \mathfrak{M}_ F(\mu)$ 이고
 
-$$\mu^\ast(A) = \mu^\ast\left( \bigcup_ {n=1}^\infty A_n \right) = \sum_ {n=1}^\infty \mu^\ast(A_n)$$
+$$\mu^\ast(A) = \mu^\ast\left( \bigcup _{n=1}^\infty A_n \right) = \sum _{n=1}^\infty \mu^\ast(A_n)$$
 
 가 성립한다.
 
 **(Step 4)** *$\mathfrak{M}(\mu)$는 $\sigma$-ring이다.*
 
-$A_n \in \mathfrak{M}(\mu)$ 이면 $B_ {n, k} \in \mathfrak{M} _F(\mu)$ 가 존재하여 $\displaystyle A_n = \bigcup_k B_ {n,k}$ 이다. 그러면
+$A_n \in \mathfrak{M}(\mu)$ 이면 $B _{n, k} \in \mathfrak{M}_ F(\mu)$ 가 존재하여 $\displaystyle A_n = \bigcup_k B _{n,k}$ 이다. 그러면
 
-$$\bigcup_n A_n = \bigcup_ {n, k} B_ {n, k} \in \mathfrak{M}(\mu)$$
+$$\bigcup_n A_n = \bigcup _{n, k} B _{n, k} \in \mathfrak{M}(\mu)$$
 
 이다.
 
-$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M} _F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
+$A, B \in \mathfrak{M}(\mu)$ 라 하면 $A_n, B_n \in \mathfrak{M}_ F(\mu)$ 에 대해 $\displaystyle A = \bigcup A_n$, $\displaystyle B = \bigcup B_n$ 이므로,
 
-$$A \setminus B = \bigcup_ {n=1}^\infty \left( A_n \setminus B \right) = \bigcup_ {n=1}^\infty (A_n\setminus(A_n\cap B))$$
+$$A \setminus B = \bigcup _{n=1}^\infty \left( A_n \setminus B \right) = \bigcup _{n=1}^\infty (A_n\setminus(A_n\cap B))$$
 
-임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M} _F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
+임을 알 수 있다. 그러므로 $A_n \cap B \in \mathfrak{M}_ F(\mu)$ 인 것만 보이면 충분하다. 정의에 의해
 
-$$A_n \cap B = \bigcup_ {k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
+$$A_n \cap B = \bigcup _{k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
-이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M} _F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M} _F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
+이고 $\mu^\ast(A_n \cap B) \leq \mu^\ast(A_n) < \infty$ 이므로 $A_n\cap B \in \mathfrak{M}_ F(\mu)$ 이다. 따라서 $A \setminus B$ 가 $\mathfrak{M}_ F(\mu)$의 원소들의 countable 합집합으로 표현되므로 $A\setminus B \in \mathfrak{M}(\mu)$ 이다.
 
 따라서 $\mathfrak{M}(\mu)$는 $\sigma$-ring이고 $\sigma$-algebra이다.
 
@@ -257,6 +257,6 @@ $$A_n \cap B = \bigcup_ {k=1}^\infty (A_n \cap B_k) \in \mathfrak{M}(\mu)$$
 
 [^2]: $A$가 $\mu$-measurable인데 $\mu^\ast(A) < \infty$이면 $A$는 finitely $\mu$-measurable이다.
 
-[^3]: $A$가 countable union of sets in $\mathfrak{M} _F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
+[^3]: $A$가 countable union of sets in $\mathfrak{M}_ F(\mu)$이므로 $\mu^\ast$도 각 set의 $\mu^\ast$의 합이 된다.
 
-[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M} _F(\mu)$의 원소입니다.
+[^4]: 아직 증명이 끝나지 않았습니다. $A_n$은 $\mathfrak{M}(\mu)$의 원소가 아니라 $\mathfrak{M}_ F(\mu)$의 원소입니다.

--- a/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-23-construction-of-measure.md
@@ -71,7 +71,7 @@ $\mathbb{R}, \mathbb{R}^2, \mathbb{R}^3$에서 생각해보면 $m$은 곧 길이
 
 **정의.** (Outer Measure) $E \in \mathcal{P}(\mathbb{R}^p)$ 의 **outer measure** $\mu^\ast: \mathcal{P}(\mathbb{R}^p) \rightarrow[0, \infty]$ 는
 
-$$\mu^\ast(E) = \inf \left\lbrace \sum_{n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_{n=1}^\infty A_n\right\rbrace .$$
+$$\mu^\ast(E) = \inf \left\lbrace \sum_{n=1}^\infty \mu(A_n) : \text{열린집합 } A_n \in \Sigma \text{ 에 대하여 } E \subseteq\bigcup_{n=1}^\infty A_n\right\rbrace.$$
 
 로 정의한다.
 
@@ -135,7 +135,7 @@ Countably additive 조건이 성립하는 집합들만 모아서 measure를 cons
 
 - $A_1, B_2, B_1, B_2 \in \mathbb{R}^p$ 일 때, 다음이 성립한다.
 
-	$$\left.\begin{array}{c}d(A_1 \cup A_2, B_1 \cup B_2) \\d(A_1 \cap A_2, B_1 \cap B_2) \\d(A_1 \setminus A_2, B_1 \setminus B_2)\end{array}\right\rbrace \leq d(A_1, B_1) + d(A_2, B_2).$$
+	$$\left.\begin{array}{c}d(A_1 \cup A_2, B_1 \cup B_2) \\d(A_1 \cap A_2, B_1 \cap B_2) \\d(A_1 \setminus A_2, B_1 \setminus B_2)\end{array}\right\rbrace\leq d(A_1, B_1) + d(A_2, B_2).$$
 
 **정의.** (Finitely $\mu$-measurable) 집합 $A_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$ 이면 $A$가 **finitely $\mu$-measurable**이라 한다. 그리고 finitely $\mu$-measurable한 집합의 모임을 $\mathfrak{M}_F(\mu)$로 표기한다.
 
@@ -173,7 +173,7 @@ $$\mu^\ast(A) \leq d(A_N, A) + \mu^\ast(A_N) \leq 1 + \mu^\ast(A_N) < \infty$$
 
 $A, B \in \mathfrak{M}_F(\mu)$ 라 하자. 그러면 $A_n, B_n \in \Sigma$ 이 존재하여 $A_n \rightarrow A$, $B_n \rightarrow B$ 이 된다. 그러면
 
-$$\left.\begin{array}{c}d(A_n \cup B_n, A \cup B) \\ d(A_n \cap B_n, A \cap B) \\ d(A_n \setminus B_n, A \setminus B)\end{array}\right\rbrace \leq d(A_n, A) + d(B_n, B) \rightarrow 0$$
+$$\left.\begin{array}{c}d(A_n \cup B_n, A \cup B) \\ d(A_n \cap B_n, A \cap B) \\ d(A_n \setminus B_n, A \setminus B)\end{array}\right\rbrace\leq d(A_n, A) + d(B_n, B) \rightarrow 0$$
 
 이므로 $A_n \cup B_n \rightarrow A \cup B, A_n \setminus B_n \rightarrow A\setminus B$ 이기 때문에 $\mathfrak{M}_F(\mu)$는 ring이다.
 
@@ -199,7 +199,7 @@ $$\mu^\ast(A) + \mu^\ast(B) = \mu^\ast(A\cup B) + \mu^\ast(A \cap B)$$
 
 와 같이 정의하면 $A_n$이 쌍마다 서로소이고 $A_n \in \mathfrak{M}_F(\mu)$ 임을 알 수 있다.
 
-위 사실을 이용하여 $$A_n \in \mathfrak{M}_F(\mu)$$ 에 대하여 $$A = \displaystyle\bigcup_{n=1}^\infty A_n$$ 으로 두자.
+위 사실을 이용하여 $A_n \in \mathfrak{M}_ F(\mu)$ 에 대하여 $A = \displaystyle\bigcup_{n=1}^\infty A_n$ 으로 두자.
 
 1. Countable subadditivity에 의해 $\displaystyle\mu^\ast(A) \leq \sum_{n=1}^{\infty} \mu^\ast (A_n)$ 가 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
@@ -67,7 +67,7 @@ $$F_n \subseteq A \subseteq G_n, \quad \mu\left( G_n \setminus A \right) < \frac
 
 한편, $A = F \cup (A \setminus F)$, $G = A \cup (G \setminus A)$ 로 적을 수 있다. 그런데 $n \rightarrow\infty$ 일 때
 
-$$\left.\begin{array}{r}\mu\left( G \setminus A \right)\leq \mu\left( G_n \setminus A \right) < \frac{1}{n} \\        \mu\left( A \setminus F \right) \leq \mu\left( A \setminus F_n \right) < \frac{1}{n}\end{array}\right\rbrace     \rightarrow 0$$
+$$\left.\begin{array}{r}\mu\left( G \setminus A \right)\leq \mu\left( G_n \setminus A \right) < \frac{1}{n} \\        \mu\left( A \setminus F \right) \leq \mu\left( A \setminus F_n \right) < \frac{1}{n}\end{array}\right\rbrace    \rightarrow 0$$
 
 이므로 $A \in \mathfrak{M}(\mu)$ 는 Borel set 과 $\mu$-measure zero set의 합집합이다. 그리고 $A \in \mathfrak{M}(\mu)$ 에 적당한 $\mu$-measure zero set을 합집합하여 Borel set이 되게 할 수 있다.
 
@@ -118,4 +118,3 @@ Uncountable인 경우에는 Cantor set $P$를 생각한다. $E_n$을 다음과 �
 [^1]: 첫 번째 부등식은 countable subadditivity, 두 번째 부등식은 $\mu^\ast$의 정의에서 나온다.
 
 [^2]: [Vitali set](https://en.wikipedia.org/wiki/Vitali_set) 참고.
-

--- a/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
@@ -19,11 +19,11 @@ Construction of measure 증명에서 추가로 참고할 내용입니다.
 
 **명제.** $A$가 열린집합이면 $A \in \mathfrak{M}(\mu)$ 이다. 또한 $A^C \in \mathfrak{M}(\mu)$ 이므로, $F$가 닫힌집합이면 $F \in \mathfrak{M}(\mu)$ 이다.
 
-**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M}_ F(\mu)$의 원소이다. 이제
+**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M} _ F(\mu)$의 원소이다. 이제
 
-$$A = \bigcup _{\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
+$$A = \bigcup_ {\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
 
-로 적을 수 있으므로 $A$는 $\mathfrak{M}_ F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
+로 적을 수 있으므로 $A$는 $\mathfrak{M} _ F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
 
 **명제.** $A \in \mathfrak{M}(\mu)$ 이면 임의의 $\epsilon > 0$ 에 대하여
 
@@ -33,15 +33,15 @@ $$F \subseteq A \subseteq G, \quad \mu\left( G \setminus A \right) < \epsilon, \
 
 이는 곧 정의역을 $\mathfrak{M}(\mu)$로 줄였음에도 $\mu$가 여전히 $\mathfrak{M}(\mu)$ 위에서 regular라는 뜻입니다.
 
-**증명.** $A = \bigcup _{n=1}^\infty A_n$ ($A_n \in \mathfrak{M}_ F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B _{n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup _{k=1}^\infty B _{n, k}$ 와
+**증명.** $A = \bigcup_ {n=1}^\infty A_n$ ($A_n \in \mathfrak{M} _ F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B_ {n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup_ {k=1}^\infty B_ {n, k}$ 와
 
-$$\mu\left( \bigcup _{k=1}^{\infty} B _{n, k} \right) \leq \sum _{k=1}^{\infty} \mu\left( B _{n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
+$$\mu\left( \bigcup_ {k=1}^{\infty} B_ {n, k} \right) \leq \sum_ {k=1}^{\infty} \mu\left( B_ {n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
 
 을 만족하도록 할 수 있다.[^1]
 
-이제 열린집합을 잡아보자. $G_n = \bigcup _{k=1}^{\infty} B _{n, k}$ 으로 두고 $G = \bigcup _{n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M}_ F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
+이제 열린집합을 잡아보자. $G_n = \bigcup_ {k=1}^{\infty} B_ {n, k}$ 으로 두고 $G = \bigcup_ {n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M} _ F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
 
-$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup _{n=1}^{\infty} G_n \setminus\bigcup _{n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup _{n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum _{n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum _{n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
+$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus\bigcup_ {n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum_ {n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum_ {n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
 
 닫힌집합의 존재성을 보이기 위해 위 과정을 $A^C$에 대해 반복하면 $A^C \subseteq F^C$, $\mu\left( F^C \setminus A^C \right) < \epsilon$ 가 되도록 열린집합 $F^C$를 잡을 수 있다. $F$가 닫힌집합이고 $F^C \setminus A^C = F^C \cap A = A\setminus F$ 이므로 $\mu\left( A \setminus F \right) < \epsilon$ 이고 $F\subseteq A$ 이다.
 
@@ -49,7 +49,7 @@ $$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup _
 
 Borel $\sigma$-algebra는 $\mathbb{R}^p$의 열린집합을 포함하는 가장 작은 $\sigma$-algebra로 정의할 수도 있습니다. $O$가 $\mathbb{R}^p$의 열린집합의 모임이라 하면
 
-$$\mathfrak{B} = \bigcap _{O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
+$$\mathfrak{B} = \bigcap_ {O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 로 정의합니다. 여기서 '가장 작은'의 의미는 집합의 관점에서 가장 작다는 의미로, 위 조건을 만족하는 임의의 집합 $X$를 가져오더라도 $X \subseteq\mathfrak{B}$ 라는 뜻입니다. 그래서 교집합을 택하게 됩니다. 위 정의에 의해 $\mathfrak{B} \subseteq\mathfrak{M}(\mu)$ 임도 알 수 있습니다.
 
@@ -63,7 +63,7 @@ $$\mathfrak{B} = \bigcap _{O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 $$F_n \subseteq A \subseteq G_n, \quad \mu\left( G_n \setminus A \right) < \frac{1}{n}, \quad \mu\left( A \setminus F_n \right) < \frac{1}{n}.$$
 
-이제 $F = \bigcup _{n=1}^{\infty} F_n$, $G = \bigcap _{n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
+이제 $F = \bigcup_ {n=1}^{\infty} F_n$, $G = \bigcap_ {n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
 
 한편, $A = F \cup (A \setminus F)$, $G = A \cup (G \setminus A)$ 로 적을 수 있다. 그런데 $n \rightarrow\infty$ 일 때
 
@@ -75,7 +75,7 @@ $$\left.\begin{array}{r}\mu\left( G \setminus A \right)\leq \mu\left( G_n \setmi
 
 **증명.** Countable subadditivity를 확인하면 나머지는 자명하다. 모든 $n\in \mathbb{N}$ 에 대하여 $\mu\left( A_n \right) = 0$ 이라 하면
 
-$$\mu\left( \bigcup _{n=1}^{\infty} A_n \right) \leq \sum _{n=1}^{\infty} \mu\left( A_n \right) = 0$$
+$$\mu\left( \bigcup_ {n=1}^{\infty} A_n \right) \leq \sum_ {n=1}^{\infty} \mu\left( A_n \right) = 0$$
 
 이다.
 
@@ -91,7 +91,7 @@ Uncountable인 경우에는 Cantor set $P$를 생각한다. $E_n$을 다음과 �
 
 - $E_2 = \left[0, \frac{1}{9}\right] \cup \left[\frac{2}{9}, \frac{3}{9}\right] \cup \left[\frac{6}{9}, \frac{7}{9}\right] \cup \left[\frac{8}{9}, 1\right]$, 마찬가지로 $E_1$의 구간을 3등분하여 가운데를 제외한 것이다.
 
-위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap _{n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
+위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap_ {n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
 
 **참고.** $\mathfrak{M}(m) \subsetneq \mathcal{P}(\mathbb{R}^p)$. $\mathbb{R}^p$의 부분집합 중 measurable하지 않은 집합이 존재한다.[^2]
 

--- a/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
@@ -19,11 +19,11 @@ Construction of measure 증명에서 추가로 참고할 내용입니다.
 
 **명제.** $A$가 열린집합이면 $A \in \mathfrak{M}(\mu)$ 이다. 또한 $A^C \in \mathfrak{M}(\mu)$ 이므로, $F$가 닫힌집합이면 $F \in \mathfrak{M}(\mu)$ 이다.
 
-**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M} _F(\mu)$의 원소이다. 이제
+**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M}_ F(\mu)$의 원소이다. 이제
 
-$$A = \bigcup_ {\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
+$$A = \bigcup _{\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
 
-로 적을 수 있으므로 $A$는 $\mathfrak{M} _F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
+로 적을 수 있으므로 $A$는 $\mathfrak{M}_ F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
 
 **명제.** $A \in \mathfrak{M}(\mu)$ 이면 임의의 $\epsilon > 0$ 에 대하여
 
@@ -33,15 +33,15 @@ $$F \subseteq A \subseteq G, \quad \mu\left( G \setminus A \right) < \epsilon, \
 
 이는 곧 정의역을 $\mathfrak{M}(\mu)$로 줄였음에도 $\mu$가 여전히 $\mathfrak{M}(\mu)$ 위에서 regular라는 뜻입니다.
 
-**증명.** $A = \bigcup_ {n=1}^\infty A_n$ ($A_n \in \mathfrak{M} _F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B_ {n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup_ {k=1}^\infty B_ {n, k}$ 와
+**증명.** $A = \bigcup _{n=1}^\infty A_n$ ($A_n \in \mathfrak{M}_ F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B _{n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup _{k=1}^\infty B _{n, k}$ 와
 
-$$\mu\left( \bigcup_ {k=1}^{\infty} B_ {n, k} \right) \leq \sum_ {k=1}^{\infty} \mu\left( B_ {n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
+$$\mu\left( \bigcup _{k=1}^{\infty} B _{n, k} \right) \leq \sum _{k=1}^{\infty} \mu\left( B _{n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
 
 을 만족하도록 할 수 있다.[^1]
 
-이제 열린집합을 잡아보자. $G_n = \bigcup_ {k=1}^{\infty} B_ {n, k}$ 으로 두고 $G = \bigcup_ {n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M} _F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
+이제 열린집합을 잡아보자. $G_n = \bigcup _{k=1}^{\infty} B _{n, k}$ 으로 두고 $G = \bigcup _{n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M}_ F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
 
-$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus\bigcup_ {n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum_ {n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum_ {n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
+$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup _{n=1}^{\infty} G_n \setminus\bigcup _{n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup _{n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum _{n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum _{n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
 
 닫힌집합의 존재성을 보이기 위해 위 과정을 $A^C$에 대해 반복하면 $A^C \subseteq F^C$, $\mu\left( F^C \setminus A^C \right) < \epsilon$ 가 되도록 열린집합 $F^C$를 잡을 수 있다. $F$가 닫힌집합이고 $F^C \setminus A^C = F^C \cap A = A\setminus F$ 이므로 $\mu\left( A \setminus F \right) < \epsilon$ 이고 $F\subseteq A$ 이다.
 
@@ -49,7 +49,7 @@ $$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_ 
 
 Borel $\sigma$-algebra는 $\mathbb{R}^p$의 열린집합을 포함하는 가장 작은 $\sigma$-algebra로 정의할 수도 있습니다. $O$가 $\mathbb{R}^p$의 열린집합의 모임이라 하면
 
-$$\mathfrak{B} = \bigcap_ {O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
+$$\mathfrak{B} = \bigcap _{O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 로 정의합니다. 여기서 '가장 작은'의 의미는 집합의 관점에서 가장 작다는 의미로, 위 조건을 만족하는 임의의 집합 $X$를 가져오더라도 $X \subseteq\mathfrak{B}$ 라는 뜻입니다. 그래서 교집합을 택하게 됩니다. 위 정의에 의해 $\mathfrak{B} \subseteq\mathfrak{M}(\mu)$ 임도 알 수 있습니다.
 
@@ -63,7 +63,7 @@ $$\mathfrak{B} = \bigcap_ {O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 $$F_n \subseteq A \subseteq G_n, \quad \mu\left( G_n \setminus A \right) < \frac{1}{n}, \quad \mu\left( A \setminus F_n \right) < \frac{1}{n}.$$
 
-이제 $F = \bigcup_ {n=1}^{\infty} F_n$, $G = \bigcap_ {n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
+이제 $F = \bigcup _{n=1}^{\infty} F_n$, $G = \bigcap _{n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
 
 한편, $A = F \cup (A \setminus F)$, $G = A \cup (G \setminus A)$ 로 적을 수 있다. 그런데 $n \rightarrow\infty$ 일 때
 
@@ -75,7 +75,7 @@ $$\left.\begin{array}{r}\mu\left( G \setminus A \right)\leq \mu\left( G_n \setmi
 
 **증명.** Countable subadditivity를 확인하면 나머지는 자명하다. 모든 $n\in \mathbb{N}$ 에 대하여 $\mu\left( A_n \right) = 0$ 이라 하면
 
-$$\mu\left( \bigcup_ {n=1}^{\infty} A_n \right) \leq \sum_ {n=1}^{\infty} \mu\left( A_n \right) = 0$$
+$$\mu\left( \bigcup _{n=1}^{\infty} A_n \right) \leq \sum _{n=1}^{\infty} \mu\left( A_n \right) = 0$$
 
 이다.
 
@@ -91,7 +91,7 @@ Uncountable인 경우에는 Cantor set $P$를 생각한다. $E_n$을 다음과 �
 
 - $E_2 = \left[0, \frac{1}{9}\right] \cup \left[\frac{2}{9}, \frac{3}{9}\right] \cup \left[\frac{6}{9}, \frac{7}{9}\right] \cup \left[\frac{8}{9}, 1\right]$, 마찬가지로 $E_1$의 구간을 3등분하여 가운데를 제외한 것이다.
 
-위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap_ {n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
+위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap _{n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
 
 **참고.** $\mathfrak{M}(m) \subsetneq \mathcal{P}(\mathbb{R}^p)$. $\mathbb{R}^p$의 부분집합 중 measurable하지 않은 집합이 존재한다.[^2]
 

--- a/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
+++ b/_posts/Mathematics/Measure Theory/2023-01-24-measure-spaces.md
@@ -19,11 +19,11 @@ Construction of measure 증명에서 추가로 참고할 내용입니다.
 
 **명제.** $A$가 열린집합이면 $A \in \mathfrak{M}(\mu)$ 이다. 또한 $A^C \in \mathfrak{M}(\mu)$ 이므로, $F$가 닫힌집합이면 $F \in \mathfrak{M}(\mu)$ 이다.
 
-**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M}_F(\mu)$의 원소이다. 이제
+**증명.** 중심이 $x\in \mathbb{R}^p$ 이고 반지름이 $r$인 열린 box를 $I(x, r)$이라 두자. $I(x, r)$은 명백히 $\mathfrak{M} _F(\mu)$의 원소이다. 이제
 
-$$A = \bigcup_{\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
+$$A = \bigcup_ {\substack{x \in \mathbb{Q}^p, \; r \in \mathbb{Q}\\ I(x, r)\subseteq A}} I(x, r)$$
 
-로 적을 수 있으므로 $A$는 $\mathfrak{M}_F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
+로 적을 수 있으므로 $A$는 $\mathfrak{M} _F(\mu)$의 원소들의 countable union이 되어 $A \in \mathfrak{M}(\mu)$ 이다. 이제 $\mathfrak{M}(\mu)$가 $\sigma$-algebra이므로 $A^C\in \mathfrak{M}(\mu)$ 이고, 이로부터 임의의 닫힌집합 $F$도 $\mathfrak{M}(\mu)$의 원소임을 알 수 있다.
 
 **명제.** $A \in \mathfrak{M}(\mu)$ 이면 임의의 $\epsilon > 0$ 에 대하여
 
@@ -33,15 +33,15 @@ $$F \subseteq A \subseteq G, \quad \mu\left( G \setminus A \right) < \epsilon, \
 
 이는 곧 정의역을 $\mathfrak{M}(\mu)$로 줄였음에도 $\mu$가 여전히 $\mathfrak{M}(\mu)$ 위에서 regular라는 뜻입니다.
 
-**증명.** $A = \bigcup_{n=1}^\infty A_n$ ($A_n \in \mathfrak{M}_F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B_{n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup_{k=1}^\infty B_{n, k}$ 와
+**증명.** $A = \bigcup_ {n=1}^\infty A_n$ ($A_n \in \mathfrak{M} _F(\mu)$) 로 두고 $\epsilon > 0$ 을 고정하자. 각 $n \in \mathbb{N}$ 에 대하여 열린집합 $B_ {n, k} \in \Sigma$ 를 잡아 $A_n \subseteq\bigcup_ {k=1}^\infty B_ {n, k}$ 와
 
-$$\mu\left( \bigcup_{k=1}^{\infty} B_{n, k} \right) \leq \sum_{k=1}^{\infty} \mu\left( B_{n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
+$$\mu\left( \bigcup_ {k=1}^{\infty} B_ {n, k} \right) \leq \sum_ {k=1}^{\infty} \mu\left( B_ {n, k} \right) < \mu\left( A_n \right) + 2^{-n}\epsilon$$
 
 을 만족하도록 할 수 있다.[^1]
 
-이제 열린집합을 잡아보자. $G_n = \bigcup_{k=1}^{\infty} B_{n, k}$ 으로 두고 $G = \bigcup_{n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M}_F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
+이제 열린집합을 잡아보자. $G_n = \bigcup_ {k=1}^{\infty} B_ {n, k}$ 으로 두고 $G = \bigcup_ {n=1}^{\infty} G_n$ 로 잡는다. $A_n \in \mathfrak{M} _F(\mu)$ 이므로 $\mu\left( A_n \right) < \infty$ 이고, 다음이 성립한다.
 
-$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_{n=1}^{\infty} G_n \setminus\bigcup_{n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup_{n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum_{n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum_{n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
+$$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus\bigcup_ {n=1}^{\infty} A_n \right) \leq \mu\left( \bigcup_ {n=1}^{\infty} G_n \setminus A_n \right) \\ &\leq \sum_ {n=1}^{\infty} \mu\left( G_n \setminus A_n \right) \leq \sum_ {n=1}^{\infty} 2^{-n}\epsilon = \epsilon.    \end{aligned}$$
 
 닫힌집합의 존재성을 보이기 위해 위 과정을 $A^C$에 대해 반복하면 $A^C \subseteq F^C$, $\mu\left( F^C \setminus A^C \right) < \epsilon$ 가 되도록 열린집합 $F^C$를 잡을 수 있다. $F$가 닫힌집합이고 $F^C \setminus A^C = F^C \cap A = A\setminus F$ 이므로 $\mu\left( A \setminus F \right) < \epsilon$ 이고 $F\subseteq A$ 이다.
 
@@ -49,7 +49,7 @@ $$\begin{aligned}        \mu\left( G \setminus A \right) & = \mu\left( \bigcup_{
 
 Borel $\sigma$-algebra는 $\mathbb{R}^p$의 열린집합을 포함하는 가장 작은 $\sigma$-algebra로 정의할 수도 있습니다. $O$가 $\mathbb{R}^p$의 열린집합의 모임이라 하면
 
-$$\mathfrak{B} = \bigcap_{O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
+$$\mathfrak{B} = \bigcap_ {O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 로 정의합니다. 여기서 '가장 작은'의 의미는 집합의 관점에서 가장 작다는 의미로, 위 조건을 만족하는 임의의 집합 $X$를 가져오더라도 $X \subseteq\mathfrak{B}$ 라는 뜻입니다. 그래서 교집합을 택하게 됩니다. 위 정의에 의해 $\mathfrak{B} \subseteq\mathfrak{M}(\mu)$ 임도 알 수 있습니다.
 
@@ -63,7 +63,7 @@ $$\mathfrak{B} = \bigcap_{O \subseteq G,\;G:\, \sigma\text{-algebra}} G$$
 
 $$F_n \subseteq A \subseteq G_n, \quad \mu\left( G_n \setminus A \right) < \frac{1}{n}, \quad \mu\left( A \setminus F_n \right) < \frac{1}{n}.$$
 
-이제 $F = \bigcup_{n=1}^{\infty} F_n$, $G = \bigcap_{n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
+이제 $F = \bigcup_ {n=1}^{\infty} F_n$, $G = \bigcap_ {n=1}^{\infty} G_n$ 로 정의하면 $F, G \in \mathfrak{B}$ 이고 $F \subseteq A \subseteq G$ 이다.
 
 한편, $A = F \cup (A \setminus F)$, $G = A \cup (G \setminus A)$ 로 적을 수 있다. 그런데 $n \rightarrow\infty$ 일 때
 
@@ -75,7 +75,7 @@ $$\left.\begin{array}{r}\mu\left( G \setminus A \right)\leq \mu\left( G_n \setmi
 
 **증명.** Countable subadditivity를 확인하면 나머지는 자명하다. 모든 $n\in \mathbb{N}$ 에 대하여 $\mu\left( A_n \right) = 0$ 이라 하면
 
-$$\mu\left( \bigcup_{n=1}^{\infty} A_n \right) \leq \sum_{n=1}^{\infty} \mu\left( A_n \right) = 0$$
+$$\mu\left( \bigcup_ {n=1}^{\infty} A_n \right) \leq \sum_ {n=1}^{\infty} \mu\left( A_n \right) = 0$$
 
 이다.
 
@@ -91,7 +91,7 @@ Uncountable인 경우에는 Cantor set $P$를 생각한다. $E_n$을 다음과 �
 
 - $E_2 = \left[0, \frac{1}{9}\right] \cup \left[\frac{2}{9}, \frac{3}{9}\right] \cup \left[\frac{6}{9}, \frac{7}{9}\right] \cup \left[\frac{8}{9}, 1\right]$, 마찬가지로 $E_1$의 구간을 3등분하여 가운데를 제외한 것이다.
 
-위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap_{n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
+위 과정을 반복하여 $E_n$을 얻고, Cantor set은 $P = \bigcap_ {n=1}^{\infty} E_n$ 로 정의한다. 여기서 $m(E_n) = \left( \frac{2}{3} \right)^n$ 임을 알 수 있고, $P \subseteq E_n$ 이므로 $m(P)\leq m(E_n)$ 가 성립한다. 이제 $n \rightarrow\infty$ 로 두면 $m(P) = 0$ 이다.
 
 **참고.** $\mathfrak{M}(m) \subsetneq \mathcal{P}(\mathbb{R}^p)$. $\mathbb{R}^p$의 부분집합 중 measurable하지 않은 집합이 존재한다.[^2]
 

--- a/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
@@ -47,7 +47,7 @@ $$\lbrace x \in X : f(x) > a\rbrace$$
 
 **증명.** 우선 (1)을 가정하고, 다음 관계식을 이용하면
 
-$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup _{n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup _{n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
 
 measurable set의 countable union도 measurable이므로 ($\sigma$-algebra) (2)가 성립한다. 이제 (2)를 가정하면
 
@@ -55,7 +55,7 @@ $$\lbrace x : f(x) < a\rbrace = X \setminus\lbrace x : f(x) \geq a\rbrace$$
 
 로부터 (3)이 성립하는 것을 알 수 있다. (3)을 가정하면 위와 마찬가지 방법으로
 
-$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup _{n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup _{n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
 
 과 같이 변형하여 (4)가 성립함을 알 수 있다. 마지막으로 (4)를 가정하면
 
@@ -97,17 +97,17 @@ $$\begin{aligned}        \lbrace x : \max\lbrace f, g\rbrace > a\rbrace & = \lbr
 
 **정리.** $\lbrace f_n\rbrace$가 measurable 함수열이라 하자. 그러면
 
-$$\sup_ {n\in \mathbb{N}} f_n, \quad \inf_ {n\in \mathbb{N}} f_n, \quad \limsup_ {n \rightarrow\infty} f_n, \quad \liminf_ {n \rightarrow\infty} f_n$$
+$$\sup _{n\in \mathbb{N}} f_n, \quad \inf _{n\in \mathbb{N}} f_n, \quad \limsup _{n \rightarrow\infty} f_n, \quad \liminf _{n \rightarrow\infty} f_n$$
 
 은 모두 measurable이다.
 
 **증명.** 다음이 성립한다.
 
-$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup_ {k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
+$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup _{k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
 
 따라서 위 명제는 $\sup f_n$에 대해서만 보이면 충분하다. 이제 $\sup f_n$이 measurable function인 것은
 
-$$\lbrace x : \sup_ {n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup_ {n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
+$$\lbrace x : \sup _{n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup _{n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
 
 로부터 당연하다.
 
@@ -121,11 +121,11 @@ $\lim f_n$이 존재하는 경우, 위 명제를 이용하면 $\lim f_n = \limsu
 
 **증명.** $a \in \mathbb{R}$ 에 대하여 $G_a = \lbrace (u, v)\in \mathbb{R}^2 : F(u, v) > a\rbrace$ 로 정의합니다. 그러면 $F$가 연속이므로 $G_a$는 열린집합이고, $G_a$ 열린구간의 합집합으로 적을 수 있다. 따라서 $a_n, b_n, c_n, d_n\in \mathbb{R}$ 에 대하여
 
-$$G_a = \displaystyle\bigcup_ {n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
+$$G_a = \displaystyle\bigcup _{n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
 
 로 두면
 
-$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
+$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup _{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup _{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
 
 이다. 여기서 $f, g$가 measurable이므로 $\lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace$도 measurable이다. 이로부터 $F(x, y) = x + y$, $F(x, y) = xy$ 인 경우를 고려하면 $f+g$, $fg$가 measurable임을 알 수 있다.
 
@@ -137,7 +137,7 @@ $$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = 
 
 $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cases}$$
 
-참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1} _E, K_E$로 표기하는 경우도 있습니다.
+참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1}_ E, K_E$로 표기하는 경우도 있습니다.
 
 ## Simple Function
 
@@ -147,11 +147,11 @@ $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cas
 
 **참고.** 치역의 원소를 잡아 $s(X) = \lbrace c_1, c_2, \dots, c_n\rbrace$ 로 두자. 여기서 $E_i = s^{-1}(c_i)$ 로 두면 다음과 같이 적을 수 있다.
 
-$$s(x) = \sum_ {i=1}^{n} c_i \chi_ {E_i}(x).$$
+$$s(x) = \sum _{i=1}^{n} c_i \chi _{E_i}(x).$$
 
 이로부터 모든 simple function은 characteristic function의 linear combination으로 표현됨을 알 수 있습니다. 물론 $E_i$는 쌍마다 서로소입니다.
 
-여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi_ {E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi_ {E_i}$의 linear combination으로 표현할 수 있습니다.
+여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi _{E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi _{E_i}$의 linear combination으로 표현할 수 있습니다.
 
 ![mt-04.png](../../../assets/img/posts/mt-04.png)
 
@@ -159,27 +159,27 @@ $$s(x) = \sum_ {i=1}^{n} c_i \chi_ {E_i}(x).$$
 
 **정리.** $f : X \rightarrow\overline{\mathbb{R}}$ 라 두자. 모든 $x \in X$ 에 대하여
 
-$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
+$$\lim _{n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
 
 인 simple 함수열 $s_n$이 존재한다. 여기서 추가로
 
 1. $f$가 유계이면 $s_n$은 $f$로 고르게 수렴한다.
 
-2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
+2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup _{n\in \mathbb{N}} s_n = f$ 이다.
 
 3. **$f$가 measurable이면 measurable simple 함수열 $s_n$이 존재한다.**
 
-**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E_ {n, i}$를 다음과 같이 정의한다.
+**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E _{n, i}$를 다음과 같이 정의한다.
 
-$$E_ {n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
+$$E _{n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
 
 이를 이용하여
 
-$$s_n(x) = \sum_ {n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi_ {E_ {n, i}} (x)$$
+$$s_n(x) = \sum _{n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi _{E _{n, i}} (x)$$
 
-로 두면 $s_n$은 simple function이다. 여기서 $E_ {n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
+로 두면 $s_n$은 simple function이다. 여기서 $E _{n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
 
-$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
+$$\lim _{n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
 
 라 할 수 있다.
 
@@ -189,9 +189,9 @@ $$\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$$
 
 가 되어 $s_n$이 $f$로 고르게 수렴함을 알 수 있다.
 
-(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s_ {n+1}(x)$ 이므로 당연히 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
+(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s _{n+1}(x)$ 이므로 당연히 $\displaystyle\sup _{n\in \mathbb{N}} s_n = f$ 이다.
 
-(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E_ {n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
+(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E _{n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
 
 이제 일반적인 $f$에 대해서는 $f = f^+ - f^-$ 로 적는다.[^3] 그러면 앞서 증명한 사실을 이용해 $g_n \rightarrow f^+$, $h_n \rightarrow f^-$ 인 simple function $g_n, h_n$을 잡을 수 있다. 이제 $s_n = g_n - h_n$ 으로 두면 $\lvert s_n(x) \rvert \leq \lvert f(x) \rvert$ 가 성립하고, $s_n \rightarrow f$ 도 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
@@ -31,35 +31,35 @@ $$\lbrace x \in X : f(x) > a\rbrace$$
 
 **따름정리.** $\mathbb{R}^p$에서 정의된 연속함수는 Lebesgue measurable이다.
 
-**증명.** 임의의 $a \in \mathbb{R}$ 에 대해 $\lbrace x : f(x) > a\rbrace $가 $\mathbb{R}^p$의 열린집합이므로, $\mathfrak{M}(m)$의 원소가 되어 measurable이다.
+**증명.** 임의의 $a \in \mathbb{R}$ 에 대해 $\lbrace x : f(x) > a\rbrace$가 $\mathbb{R}^p$의 열린집합이므로, $\mathfrak{M}(m)$의 원소가 되어 measurable이다.
 
 위 정의를 보고 생각하다 보면 굳이 $f(x) > a$ 로 정의해야 했나 의문이 생깁니다. $f(x) \geq a$, $f(x) < a$ 를 사용할 수도 있었을 것입니다.
 
 **정리.** Measurable space $X$ 위에서 정의된 함수 $f$가 주어졌을 때, 다음은 동치이다.
 
-1. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) > a\rbrace $는 measurable이다.
+1. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) > a\rbrace$는 measurable이다.
 
-2. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) \geq a\rbrace $는 measurable이다.
+2. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) \geq a\rbrace$는 measurable이다.
 
-3. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) < a\rbrace $는 measurable이다.
+3. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) < a\rbrace$는 measurable이다.
 
-4. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) \leq a\rbrace $는 measurable이다.
+4. 모든 $a \in \mathbb{R}$ 에 대하여 $\lbrace x : f(x) \leq a\rbrace$는 measurable이다.
 
 **증명.** 우선 (1)을 가정하고, 다음 관계식을 이용하면
 
-$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace  & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
 
 measurable set의 countable union도 measurable이므로 ($\sigma$-algebra) (2)가 성립한다. 이제 (2)를 가정하면
 
-$$\lbrace x : f(x) < a\rbrace  = X \setminus\lbrace x : f(x) \geq a\rbrace$$
+$$\lbrace x : f(x) < a\rbrace = X \setminus\lbrace x : f(x) \geq a\rbrace$$
 
 로부터 (3)이 성립하는 것을 알 수 있다. (3)을 가정하면 위와 마찬가지 방법으로
 
-$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace  & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
 
 과 같이 변형하여 (4)가 성립함을 알 수 있다. 마지막으로 (4)를 가정하면
 
-$$\lbrace x : f(x) > a\rbrace  = X \setminus\lbrace x : f(x) \leq a\rbrace$$
+$$\lbrace x : f(x) > a\rbrace = X \setminus\lbrace x : f(x) \leq a\rbrace$$
 
 로부터 (1)이 성립함을 알 수 있다.
 
@@ -71,7 +71,7 @@ $$\lbrace x : f(x) > a\rbrace  = X \setminus\lbrace x : f(x) \leq a\rbrace$$
 
 **증명.** 다음 관계로부터 자명하다.
 
-$$\lbrace x : \lvert f(x) \rvert < a\rbrace  = \lbrace x : f(x) < a\rbrace  \cap \lbrace x : f(x) > -a\rbrace .$$
+$$\lbrace x : \lvert f(x) \rvert < a\rbrace = \lbrace x : f(x) < a\rbrace \cap \lbrace x : f(x) > -a\rbrace.$$
 
 역은 성립할까요?
 
@@ -79,23 +79,23 @@ $$\lbrace x : \lvert f(x) \rvert < a\rbrace  = \lbrace x : f(x) < a\rbrace  \cap
 
 $$g(x) = \begin{cases}        x & (x \in S) \\ -x & (x \notin S).    \end{cases}$$
 
-그러면 모든 $x \in \mathbb{R}$ 에 대해 $\lvert g(x) \rvert = x$ 이므로 $\lvert g \rvert$는 measurable function이다. 하지만 $\lbrace x : g(x) > 0\rbrace  = \mathbb{R}\setminus(-\infty, 0] = S$ 는 measurable이 아니므로 $g$는 measurable function이 아니다.
+그러면 모든 $x \in \mathbb{R}$ 에 대해 $\lvert g(x) \rvert = x$ 이므로 $\lvert g \rvert$는 measurable function이다. 하지만 $\lbrace x : g(x) > 0\rbrace = \mathbb{R}\setminus(-\infty, 0] = S$ 는 measurable이 아니므로 $g$는 measurable function이 아니다.
 
 **명제.** $f, g$가 measurable function이라 하자.
 
-1. $\max\lbrace f, g\rbrace $, $\min\lbrace f, g\rbrace $는 measurable function이다.
+1. $\max\lbrace f, g\rbrace$, $\min\lbrace f, g\rbrace$는 measurable function이다.
 
-2. $f^+ = \max\lbrace f, 0\rbrace $, $f^- = -\min\lbrace f, 0\rbrace $ 는 measurable function이다.
+2. $f^+ = \max\lbrace f, 0\rbrace$, $f^- = -\min\lbrace f, 0\rbrace$ 는 measurable function이다.
 
 **증명.** 다음과 같이 적는다.
 
-$$\begin{aligned}        \lbrace x : \max\lbrace f, g\rbrace  > a\rbrace  & = \lbrace x : f(x) > a\rbrace  \cup \lbrace x : g(x) > a\rbrace  \\        \lbrace x : \min\lbrace f, g\rbrace  < a\rbrace  & = \lbrace x : f(x) < a\rbrace  \cup \lbrace x : g(x) < a\rbrace     \end{aligned}$$
+$$\begin{aligned}        \lbrace x : \max\lbrace f, g\rbrace > a\rbrace & = \lbrace x : f(x) > a\rbrace \cup \lbrace x : g(x) > a\rbrace \\        \lbrace x : \min\lbrace f, g\rbrace < a\rbrace & = \lbrace x : f(x) < a\rbrace \cup \lbrace x : g(x) < a\rbrace    \end{aligned}$$
 
 그리고 (2)는 (1)에 의해 자명하다.
 
 다음은 함수열의 경우입니다. Measurable 함수열의 극한함수도 measurable일까요?
 
-**정리.** $\lbrace f_n\rbrace $가 measurable 함수열이라 하자. 그러면
+**정리.** $\lbrace f_n\rbrace$가 measurable 함수열이라 하자. 그러면
 
 $$\sup_{n\in \mathbb{N}} f_n, \quad \inf_{n\in \mathbb{N}} f_n, \quad \limsup_{n \rightarrow\infty} f_n, \quad \liminf_{n \rightarrow\infty} f_n$$
 
@@ -107,7 +107,7 @@ $$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup_{k\geq n}
 
 따라서 위 명제는 $\sup f_n$에 대해서만 보이면 충분하다. 이제 $\sup f_n$이 measurable function인 것은
 
-$$\lbrace x : \sup_{n\in\mathbb{N}} f_n(x) > a\rbrace  = \bigcup_{n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace  \in \mathscr{F}$$
+$$\lbrace x : \sup_{n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup_{n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
 
 로부터 당연하다.
 
@@ -119,15 +119,15 @@ $\lim f_n$이 존재하는 경우, 위 명제를 이용하면 $\lim f_n = \limsu
 
 **정리.** $X$에서 정의된 실함수 $f, g$가 measurable이라 하자. 연속함수 $F: \mathbb{R}^2 \rightarrow\mathbb{R}$ 에 대하여 $h(x) = F\big(f(x), g(x)\big)$ 는 measurable이다. 이로부터 $f + g$와 $fg$가 measurable임을 알 수 있다.[^2]
 
-**증명.** $a \in \mathbb{R}$ 에 대하여 $G_a = \lbrace (u, v)\in \mathbb{R}^2 : F(u, v) > a\rbrace $ 로 정의합니다. 그러면 $F$가 연속이므로 $G_a$는 열린집합이고, $G_a$ 열린구간의 합집합으로 적을 수 있다. 따라서 $a_n, b_n, c_n, d_n\in \mathbb{R}$ 에 대하여
+**증명.** $a \in \mathbb{R}$ 에 대하여 $G_a = \lbrace (u, v)\in \mathbb{R}^2 : F(u, v) > a\rbrace$ 로 정의합니다. 그러면 $F$가 연속이므로 $G_a$는 열린집합이고, $G_a$ 열린구간의 합집합으로 적을 수 있다. 따라서 $a_n, b_n, c_n, d_n\in \mathbb{R}$ 에 대하여
 
 $$G_a = \displaystyle\bigcup_{n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
 
 로 두면
 
-$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace  = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace  \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace  \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace  \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace     \end{aligned}$$
+$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
 
-이다. 여기서 $f, g$가 measurable이므로 $\lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace $도 measurable이다. 이로부터 $F(x, y) = x + y$, $F(x, y) = xy$ 인 경우를 고려하면 $f+g$, $fg$가 measurable임을 알 수 있다.
+이다. 여기서 $f, g$가 measurable이므로 $\lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace$도 measurable이다. 이로부터 $F(x, y) = x + y$, $F(x, y) = xy$ 인 경우를 고려하면 $f+g$, $fg$가 measurable임을 알 수 있다.
 
 ## Characteristic Function
 
@@ -145,7 +145,7 @@ $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cas
 
 치역이 유한집합임을 이용하면 simple function은 다음과 같이 적을 수 있습니다.
 
-**참고.** 치역의 원소를 잡아 $s(X) = \lbrace c_1, c_2, \dots, c_n\rbrace $ 로 두자. 여기서 $E_i = s^{-1}(c_i)$ 로 두면 다음과 같이 적을 수 있다.
+**참고.** 치역의 원소를 잡아 $s(X) = \lbrace c_1, c_2, \dots, c_n\rbrace$ 로 두자. 여기서 $E_i = s^{-1}(c_i)$ 로 두면 다음과 같이 적을 수 있다.
 
 $$s(x) = \sum_{i=1}^{n} c_i \chi_{E_i}(x).$$
 
@@ -171,19 +171,19 @@ $$\lim_{n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lve
 
 **증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E_{n, i}$를 다음과 같이 정의한다.
 
-$$E_{n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace  & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace  & (i = n\cdot 2^n)    \end{cases}$$
+$$E_{n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
 
 이를 이용하여
 
 $$s_n(x) = \sum_{n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi_{E_{n, i}} (x)$$
 
-로 두면 $s_n$은 simple function이다. 여기서 $E_{n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace $ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace $ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
+로 두면 $s_n$은 simple function이다. 여기서 $E_{n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
 
 $$\lim_{n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
 
 라 할 수 있다.
 
-(1)을 증명하기 위해 $f$가 유계임을 가정하면, 적당한 $M > 0$ 에 대해 $f(x) < M$ 이다. 그러면 충분히 큰 $n$에 대하여 $\lbrace x : f(x) < n\rbrace  = X$ 이므로 모든 $x \in X$ 에 대해
+(1)을 증명하기 위해 $f$가 유계임을 가정하면, 적당한 $M > 0$ 에 대해 $f(x) < M$ 이다. 그러면 충분히 큰 $n$에 대하여 $\lbrace x : f(x) < n\rbrace = X$ 이므로 모든 $x \in X$ 에 대해
 
 $$\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$$
 
@@ -210,4 +210,3 @@ $$f_n + g_n \rightarrow f + g, \quad f_ng_n \rightarrow fg$$
 [^2]: 참고로 $\infty - \infty$ 의 경우는 정의되지 않으므로 생각하지 않습니다.
 
 [^3]: 이 정의에서 $\infty - \infty$ 가 나타나지 않음에 유의해야 합니다.
-

--- a/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
@@ -47,7 +47,7 @@ $$\lbrace x \in X : f(x) > a\rbrace$$
 
 **증명.** 우선 (1)을 가정하고, 다음 관계식을 이용하면
 
-$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
 
 measurable set의 countable union도 measurable이므로 ($\sigma$-algebra) (2)가 성립한다. 이제 (2)를 가정하면
 
@@ -55,7 +55,7 @@ $$\lbrace x : f(x) < a\rbrace = X \setminus\lbrace x : f(x) \geq a\rbrace$$
 
 로부터 (3)이 성립하는 것을 알 수 있다. (3)을 가정하면 위와 마찬가지 방법으로
 
-$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_{n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_{n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
 
 과 같이 변형하여 (4)가 성립함을 알 수 있다. 마지막으로 (4)를 가정하면
 
@@ -97,17 +97,17 @@ $$\begin{aligned}        \lbrace x : \max\lbrace f, g\rbrace > a\rbrace & = \lbr
 
 **정리.** $\lbrace f_n\rbrace$가 measurable 함수열이라 하자. 그러면
 
-$$\sup_{n\in \mathbb{N}} f_n, \quad \inf_{n\in \mathbb{N}} f_n, \quad \limsup_{n \rightarrow\infty} f_n, \quad \liminf_{n \rightarrow\infty} f_n$$
+$$\sup_ {n\in \mathbb{N}} f_n, \quad \inf_ {n\in \mathbb{N}} f_n, \quad \limsup_ {n \rightarrow\infty} f_n, \quad \liminf_ {n \rightarrow\infty} f_n$$
 
 은 모두 measurable이다.
 
 **증명.** 다음이 성립한다.
 
-$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup_{k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
+$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup_ {k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
 
 따라서 위 명제는 $\sup f_n$에 대해서만 보이면 충분하다. 이제 $\sup f_n$이 measurable function인 것은
 
-$$\lbrace x : \sup_{n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup_{n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
+$$\lbrace x : \sup_ {n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup_ {n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
 
 로부터 당연하다.
 
@@ -121,11 +121,11 @@ $\lim f_n$이 존재하는 경우, 위 명제를 이용하면 $\lim f_n = \limsu
 
 **증명.** $a \in \mathbb{R}$ 에 대하여 $G_a = \lbrace (u, v)\in \mathbb{R}^2 : F(u, v) > a\rbrace$ 로 정의합니다. 그러면 $F$가 연속이므로 $G_a$는 열린집합이고, $G_a$ 열린구간의 합집합으로 적을 수 있다. 따라서 $a_n, b_n, c_n, d_n\in \mathbb{R}$ 에 대하여
 
-$$G_a = \displaystyle\bigcup_{n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
+$$G_a = \displaystyle\bigcup_ {n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
 
 로 두면
 
-$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup_{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
+$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
 
 이다. 여기서 $f, g$가 measurable이므로 $\lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace$도 measurable이다. 이로부터 $F(x, y) = x + y$, $F(x, y) = xy$ 인 경우를 고려하면 $f+g$, $fg$가 measurable임을 알 수 있다.
 
@@ -137,7 +137,7 @@ $$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = 
 
 $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cases}$$
 
-참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1}_E, K_E$로 표기하는 경우도 있습니다.
+참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1} _E, K_E$로 표기하는 경우도 있습니다.
 
 ## Simple Function
 
@@ -147,11 +147,11 @@ $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cas
 
 **참고.** 치역의 원소를 잡아 $s(X) = \lbrace c_1, c_2, \dots, c_n\rbrace$ 로 두자. 여기서 $E_i = s^{-1}(c_i)$ 로 두면 다음과 같이 적을 수 있다.
 
-$$s(x) = \sum_{i=1}^{n} c_i \chi_{E_i}(x).$$
+$$s(x) = \sum_ {i=1}^{n} c_i \chi_ {E_i}(x).$$
 
 이로부터 모든 simple function은 characteristic function의 linear combination으로 표현됨을 알 수 있습니다. 물론 $E_i$는 쌍마다 서로소입니다.
 
-여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi_{E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi_{E_i}$의 linear combination으로 표현할 수 있습니다.
+여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi_ {E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi_ {E_i}$의 linear combination으로 표현할 수 있습니다.
 
 ![mt-04.png](../../../assets/img/posts/mt-04.png)
 
@@ -159,27 +159,27 @@ $$s(x) = \sum_{i=1}^{n} c_i \chi_{E_i}(x).$$
 
 **정리.** $f : X \rightarrow\overline{\mathbb{R}}$ 라 두자. 모든 $x \in X$ 에 대하여
 
-$$\lim_{n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
+$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
 
 인 simple 함수열 $s_n$이 존재한다. 여기서 추가로
 
 1. $f$가 유계이면 $s_n$은 $f$로 고르게 수렴한다.
 
-2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup_{n\in \mathbb{N}} s_n = f$ 이다.
+2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
 
 3. **$f$가 measurable이면 measurable simple 함수열 $s_n$이 존재한다.**
 
-**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E_{n, i}$를 다음과 같이 정의한다.
+**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E_ {n, i}$를 다음과 같이 정의한다.
 
-$$E_{n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
+$$E_ {n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
 
 이를 이용하여
 
-$$s_n(x) = \sum_{n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi_{E_{n, i}} (x)$$
+$$s_n(x) = \sum_ {n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi_ {E_ {n, i}} (x)$$
 
-로 두면 $s_n$은 simple function이다. 여기서 $E_{n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
+로 두면 $s_n$은 simple function이다. 여기서 $E_ {n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
 
-$$\lim_{n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
+$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
 
 라 할 수 있다.
 
@@ -189,9 +189,9 @@ $$\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$$
 
 가 되어 $s_n$이 $f$로 고르게 수렴함을 알 수 있다.
 
-(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s_{n+1}(x)$ 이므로 당연히 $\displaystyle\sup_{n\in \mathbb{N}} s_n = f$ 이다.
+(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s_ {n+1}(x)$ 이므로 당연히 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
 
-(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E_{n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
+(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E_ {n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
 
 이제 일반적인 $f$에 대해서는 $f = f^+ - f^-$ 로 적는다.[^3] 그러면 앞서 증명한 사실을 이용해 $g_n \rightarrow f^+$, $h_n \rightarrow f^-$ 인 simple function $g_n, h_n$을 잡을 수 있다. 이제 $s_n = g_n - h_n$ 으로 두면 $\lvert s_n(x) \rvert \leq \lvert f(x) \rvert$ 가 성립하고, $s_n \rightarrow f$ 도 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-06-measurable-functions.md
@@ -47,7 +47,7 @@ $$\lbrace x \in X : f(x) > a\rbrace$$
 
 **증명.** 우선 (1)을 가정하고, 다음 관계식을 이용하면
 
-$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup _{n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup _{n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \geq a\rbrace & = f^{-1}\left( [a, \infty) \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( a + \frac{1}{n}, \infty \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( a + \frac{1}{n}, \infty \right) \right)    \end{aligned}$$
 
 measurable set의 countable union도 measurable이므로 ($\sigma$-algebra) (2)가 성립한다. 이제 (2)를 가정하면
 
@@ -55,7 +55,7 @@ $$\lbrace x : f(x) < a\rbrace = X \setminus\lbrace x : f(x) \geq a\rbrace$$
 
 로부터 (3)이 성립하는 것을 알 수 있다. (3)을 가정하면 위와 마찬가지 방법으로
 
-$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup _{n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup _{n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
+$$\begin{aligned}        \lbrace x : f(x) \leq a\rbrace & = f^{-1}\left( (-\infty, a] \right) \\                            & = f^{-1}\left( \bigcup_ {n=1}^{\infty} \left( -\infty, a - \frac{1}{n} \right) \right) \\                            & = \bigcup_ {n=1}^{\infty} f^{-1}\left( \left( -\infty, a - \frac{1}{n} \right) \right)    \end{aligned}$$
 
 과 같이 변형하여 (4)가 성립함을 알 수 있다. 마지막으로 (4)를 가정하면
 
@@ -97,17 +97,17 @@ $$\begin{aligned}        \lbrace x : \max\lbrace f, g\rbrace > a\rbrace & = \lbr
 
 **정리.** $\lbrace f_n\rbrace$가 measurable 함수열이라 하자. 그러면
 
-$$\sup _{n\in \mathbb{N}} f_n, \quad \inf _{n\in \mathbb{N}} f_n, \quad \limsup _{n \rightarrow\infty} f_n, \quad \liminf _{n \rightarrow\infty} f_n$$
+$$\sup_ {n\in \mathbb{N}} f_n, \quad \inf_ {n\in \mathbb{N}} f_n, \quad \limsup_ {n \rightarrow\infty} f_n, \quad \liminf_ {n \rightarrow\infty} f_n$$
 
 은 모두 measurable이다.
 
 **증명.** 다음이 성립한다.
 
-$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup _{k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
+$$\inf f_n = -\sup\left( -f_n \right), \quad \limsup f_n = \inf_n \sup_ {k\geq n} f_k, \quad \liminf f_n = -\limsup\left( -f_n \right).$$
 
 따라서 위 명제는 $\sup f_n$에 대해서만 보이면 충분하다. 이제 $\sup f_n$이 measurable function인 것은
 
-$$\lbrace x : \sup _{n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup _{n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
+$$\lbrace x : \sup_ {n\in\mathbb{N}} f_n(x) > a\rbrace = \bigcup_ {n=1}^{\infty} \lbrace x : f_n(x) > a\rbrace \in \mathscr{F}$$
 
 로부터 당연하다.
 
@@ -121,11 +121,11 @@ $\lim f_n$이 존재하는 경우, 위 명제를 이용하면 $\lim f_n = \limsu
 
 **증명.** $a \in \mathbb{R}$ 에 대하여 $G_a = \lbrace (u, v)\in \mathbb{R}^2 : F(u, v) > a\rbrace$ 로 정의합니다. 그러면 $F$가 연속이므로 $G_a$는 열린집합이고, $G_a$ 열린구간의 합집합으로 적을 수 있다. 따라서 $a_n, b_n, c_n, d_n\in \mathbb{R}$ 에 대하여
 
-$$G_a = \displaystyle\bigcup _{n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
+$$G_a = \displaystyle\bigcup_ {n=1}^{\infty} (a_n, b_n) \times (c_n, d_n)$$
 
 로 두면
 
-$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup _{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup _{n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
+$$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = & \lbrace x \in X : \bigl(f(x), g(x)\bigr) \in G_a\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n,\, c_n < g(x) < d_n\rbrace \\        = & \bigcup_ {n=1}^{\infty} \lbrace x \in X : a_n < f(x) < b_n\rbrace \cap \lbrace x \in X : c_n < g(x) < d_n\rbrace    \end{aligned}$$
 
 이다. 여기서 $f, g$가 measurable이므로 $\lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace$도 measurable이다. 이로부터 $F(x, y) = x + y$, $F(x, y) = xy$ 인 경우를 고려하면 $f+g$, $fg$가 measurable임을 알 수 있다.
 
@@ -137,7 +137,7 @@ $$\begin{aligned}        \lbrace x \in X : F\bigl(f(x), g(x)\bigr) > a\rbrace = 
 
 $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cases}$$
 
-참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1}_ E, K_E$로 표기하는 경우도 있습니다.
+참고로 characteristic function은 indicator function 등으로도 불리며, $\mathbf{1} _ E, K_E$로 표기하는 경우도 있습니다.
 
 ## Simple Function
 
@@ -147,11 +147,11 @@ $$\chi_E(x) = \begin{cases}        1 & (x\in E) \\ 0 & (x \notin E).    \end{cas
 
 **참고.** 치역의 원소를 잡아 $s(X) = \lbrace c_1, c_2, \dots, c_n\rbrace$ 로 두자. 여기서 $E_i = s^{-1}(c_i)$ 로 두면 다음과 같이 적을 수 있다.
 
-$$s(x) = \sum _{i=1}^{n} c_i \chi _{E_i}(x).$$
+$$s(x) = \sum_ {i=1}^{n} c_i \chi_ {E_i}(x).$$
 
 이로부터 모든 simple function은 characteristic function의 linear combination으로 표현됨을 알 수 있습니다. 물론 $E_i$는 쌍마다 서로소입니다.
 
-여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi _{E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi _{E_i}$의 linear combination으로 표현할 수 있습니다.
+여기서 $E_i$에 measurable 조건이 추가되면, 정의에 의해 $\chi_ {E_i}$도 measurable function입니다. 따라서 모든 measurable simple function을 measurable $\chi_ {E_i}$의 linear combination으로 표현할 수 있습니다.
 
 ![mt-04.png](../../../assets/img/posts/mt-04.png)
 
@@ -159,27 +159,27 @@ $$s(x) = \sum _{i=1}^{n} c_i \chi _{E_i}(x).$$
 
 **정리.** $f : X \rightarrow\overline{\mathbb{R}}$ 라 두자. 모든 $x \in X$ 에 대하여
 
-$$\lim _{n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
+$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad \lvert s_n(x) \rvert \leq \lvert f(x) \rvert$$
 
 인 simple 함수열 $s_n$이 존재한다. 여기서 추가로
 
 1. $f$가 유계이면 $s_n$은 $f$로 고르게 수렴한다.
 
-2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup _{n\in \mathbb{N}} s_n = f$ 이다.
+2. $f\geq 0$ 이면 단조증가하는 함수열 $s_n$이 존재하며 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
 
 3. **$f$가 measurable이면 measurable simple 함수열 $s_n$이 존재한다.**
 
-**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E _{n, i}$를 다음과 같이 정의한다.
+**증명.** 우선 $f \geq 0$ 인 경우부터 보인다. $n \in \mathbb{N}$ 에 대하여 집합 $E_ {n, i}$를 다음과 같이 정의한다.
 
-$$E _{n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
+$$E_ {n, i} = \begin{cases}        \left\lbrace x : \dfrac{i}{2^n} \leq f(x) < \dfrac{i+1}{2^n}\right\rbrace & (i = 0, 1, \dots, n\cdot 2^n - 1) \\        \lbrace x : f(x) \geq n\rbrace & (i = n\cdot 2^n)    \end{cases}$$
 
 이를 이용하여
 
-$$s_n(x) = \sum _{n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi _{E _{n, i}} (x)$$
+$$s_n(x) = \sum_ {n=0}^{n\cdot 2^n} \frac{i}{2^n} \chi_ {E_ {n, i}} (x)$$
 
-로 두면 $s_n$은 simple function이다. 여기서 $E _{n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
+로 두면 $s_n$은 simple function이다. 여기서 $E_ {n, i}$와 $s_n$의 정의로부터 $s_n(x) \leq f(x)$ 은 자연스럽게 얻어지고, $x \in \lbrace x : f(x) < n\rbrace$ 에 대하여 $\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$ 인 것도 알 수 있다. 여기서 $f(x) \rightarrow\infty$ 로 발산하는 부분이 존재하더라도, 충분히 큰 $n$에 대하여 $\lbrace x : f(x) \geq n\rbrace$ 위에서는 $s_n(x) = n \rightarrow\infty$ 이므로 문제가 되지 않는다. 따라서
 
-$$\lim _{n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
+$$\lim_ {n \rightarrow\infty} s_n(x) = f(x), \quad (x \in X)$$
 
 라 할 수 있다.
 
@@ -189,9 +189,9 @@ $$\lvert f(x) - s_n(x) \rvert \leq 2^{-n}$$
 
 가 되어 $s_n$이 $f$로 고르게 수렴함을 알 수 있다.
 
-(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s _{n+1}(x)$ 이므로 당연히 $\displaystyle\sup _{n\in \mathbb{N}} s_n = f$ 이다.
+(2)의 경우 $s_n$의 정의에 의해 단조증가함을 알 수 있다. 여기서 $f \geq 0$ 조건은 분명히 필요하다. $s_n(x) \leq s_ {n+1}(x)$ 이므로 당연히 $\displaystyle\sup_ {n\in \mathbb{N}} s_n = f$ 이다.
 
-(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E _{n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
+(3)을 증명하기 위해 $f$가 measurable임을 가정하면 $E_ {n, i}$도 measurable이므로 $s_n$은 measurable simple 함수열이 된다.
 
 이제 일반적인 $f$에 대해서는 $f = f^+ - f^-$ 로 적는다.[^3] 그러면 앞서 증명한 사실을 이용해 $g_n \rightarrow f^+$, $h_n \rightarrow f^-$ 인 simple function $g_n, h_n$을 잡을 수 있다. 이제 $s_n = g_n - h_n$ 으로 두면 $\lvert s_n(x) \rvert \leq \lvert f(x) \rvert$ 가 성립하고, $s_n \rightarrow f$ 도 성립한다.
 

--- a/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
@@ -17,9 +17,9 @@ image:
 
 $E \in \mathscr{F}$ 일 때, 적분을 정의하기 위해
 
-$$\mathscr{F}_ E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu| _{\mathscr{F}_ E}$$
+$$\mathscr{F} _ E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu|_ {\mathscr{F} _ E}$$
 
-로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F}_ E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
+로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F} _ E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
 
 $$\int_E f \,d{\mu} = \int f \chi _E \,d{\mu}$$
 
@@ -43,13 +43,13 @@ $$\int \chi_A \,d{\mu} = \mu(A)$$
 
 다음으로 양의 값을 갖는 measurable simple function에 대해 정의합니다. $f = f^+ - f^-$ 에서 $f^+, f^-$ 모두 양의 값을 갖기 때문에 양의 값에 대해 먼저 정의합니다.
 
-**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right) _{k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right) _{k=1}^n$을 잡아
+**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right) _ {k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right) _ {k=1}^n$을 잡아
 
-$$f(x) = \sum _{k=1}^n a_k \chi _{A_k}$$
+$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k}$$
 
 와 같이 표현할 수 있다. 이제
 
-$$\int f\,d{\mu} = \sum _{k=1}^n a_k \mu(A_k) \in [0, \infty]$$
+$$\int f\,d{\mu} = \sum_ {k=1}^n a_k \mu(A_k) \in [0, \infty]$$
 
 로 정의한다.
 
@@ -61,17 +61,17 @@ Well-definedness를 증명하기 위해 임의의 linear combination을 잡아�
 
 **증명.** $f$가 다음과 같이 두 가지 방법으로 표현된다고 하자.
 
-$$f(x) = \sum _{k=1}^n a_k \chi _{A_k} = \sum _{i=1}^m b_i \chi _{B_i}.$$
+$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k} = \sum_ {i=1}^m b_i \chi_ {B_i}.$$
 
-여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C _{k, i} = A_k \cap B_i$ 로 두면
+여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C_ {k, i} = A_k \cap B_i$ 로 두면
 
-$$\sum _{k=1}^n a_k \mu(A_k) = \sum _{k=1}^n a_k \mu\left( A_k \cap \bigcup _{i=1}^m B_i \right) = \sum _{k=1}^n \sum _{i=1}^m a_k \mu(C _{k, i}),$$
+$$\sum_ {k=1}^n a_k \mu(A_k) = \sum_ {k=1}^n a_k \mu\left( A_k \cap \bigcup_ {i=1}^m B_i \right) = \sum_ {k=1}^n \sum_ {i=1}^m a_k \mu(C_ {k, i}),$$
 
-$$\sum _{i=1}^m b_i \mu(B_i) = \sum _{i=1}^{m} b_i \mu\left( B_i \cap \bigcup _{k=1}^n A_k \right)= \sum _{i=1}^m \sum _{k=1}^n b_i \mu(C _{k, i})$$
+$$\sum_ {i=1}^m b_i \mu(B_i) = \sum_ {i=1}^{m} b_i \mu\left( B_i \cap \bigcup_ {k=1}^n A_k \right)= \sum_ {i=1}^m \sum_ {k=1}^n b_i \mu(C_ {k, i})$$
 
-이다. 이 때 $C _{k, i} \neq \varnothing$ 이면 $x \in C _{k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C _{k, i} = \varnothing$ 이면 $\mu(C _{k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C _{k, i}) = a_k \mu(C _{k, i})$ 임을 알 수 있다.[^1] 따라서
+이다. 이 때 $C_ {k, i} \neq \varnothing$ 이면 $x \in C_ {k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C_ {k, i} = \varnothing$ 이면 $\mu(C_ {k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C_ {k, i}) = a_k \mu(C_ {k, i})$ 임을 알 수 있다.[^1] 따라서
 
-$$\int f \,d{\mu }= \sum _{k=1}^n a_k \mu(A_k) = \sum _{i=1}^m b_i \mu(B_i)$$
+$$\int f \,d{\mu }= \sum_ {k=1}^n a_k \mu(A_k) = \sum_ {i=1}^m b_i \mu(B_i)$$
 
 가 되어 적분값은 유일하고 위 정의가 well-defined임을 알 수 있다.
 
@@ -87,11 +87,11 @@ $$\int \left( af + bg \right) \,d{\mu} = a \int f \,d{\mu} + b \int g \,d{\mu}$$
 
 **증명.** 위 Step 2와 동일하게
 
-$$f = \sum _{j=1}^m y_j \chi _{A_j}, \quad g = \sum _{k=1}^n z_k \chi _{B_k}$$
+$$f = \sum_ {j=1}^m y_j \chi_ {A_j}, \quad g = \sum_ {k=1}^n z_k \chi_ {B_k}$$
 
-로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C _{j, k} = A_j \cap B_k$ 로 정의하면
+로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C_ {j, k} = A_j \cap B_k$ 로 정의하면
 
-$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum _{j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum _{j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum _{j} \sum_k ay_j \mu(C _{j, k}) + \sum_k \sum_j b z_k \mu(C _{j, k}) \\                                            & = \sum _{j, k} (ay_j + bz_k) \mu(C _{j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum_ {j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum_ {j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum_ {j} \sum_k ay_j \mu(C_ {j, k}) + \sum_k \sum_j b z_k \mu(C_ {j, k}) \\                                            & = \sum_ {j, k} (ay_j + bz_k) \mu(C_ {j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
 
 이다.
 
@@ -123,7 +123,7 @@ $f$보다 작은 measurable simple function의 적분값 중 상한을 택하겠
 
 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 지난 번에 보였습니다. 이 $s_n$에 대하여 적분값을 계산해보면
 
-$$\int_E s_n \,d{\mu} = \sum _{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 임을 알 수 있습니다. 이제 $n \rightarrow\infty$ 일 때 우변이 곧 $\displaystyle\int f \,d{\mu}$ 이기를 기대합니다.
 

--- a/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
@@ -17,7 +17,7 @@ image:
 
 $E \in \mathscr{F}$ 일 때, 적분을 정의하기 위해
 
-$$\mathscr{F}_E = \lbrace A \cap E : A \in \mathscr{F}\rbrace , \quad \mu_E = \mu|_{\mathscr{F}_E}$$
+$$\mathscr{F}_E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu|_{\mathscr{F}_E}$$
 
 로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F}_E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
 
@@ -113,7 +113,7 @@ $$\int f \,d{\mu} = \int \left[g + (f - g)\right] \,d{\mu} = \int g\,d{\mu} + \i
 
 **(Step 3)** $f: X \rightarrow[0, \infty]$ 가 measurable일 때,
 
-$$\int f \,d{\mu} = \sup\left\lbrace \int h \,d{\mu}: 0\leq h \leq f, h \text{ measurable and simple}\right\rbrace .$$
+$$\int f \,d{\mu} = \sup\left\lbrace \int h \,d{\mu}: 0\leq h \leq f, h \text{ measurable and simple}\right\rbrace.$$
 
 로 정의한다.
 
@@ -123,7 +123,7 @@ $f$보다 작은 measurable simple function의 적분값 중 상한을 택하겠
 
 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 지난 번에 보였습니다. 이 $s_n$에 대하여 적분값을 계산해보면
 
-$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace  \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace )$$
+$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 임을 알 수 있습니다. 이제 $n \rightarrow\infty$ 일 때 우변이 곧 $\displaystyle\int f \,d{\mu}$ 이기를 기대합니다.
 
@@ -162,4 +162,3 @@ $$f \in \mathcal{L}^1(E, \mu)$$
 $$f \in \mathcal{L}^{1}(E, \mu) \iff f^+, f^- \in \mathcal{L}^{1}(E, \mu)\iff \lvert f \rvert \in \mathcal{L}^{1}(E, \mu).$$
 
 [^1]: 계수가 같거나, measure가 0이 되어 같거나.
-

--- a/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
@@ -17,9 +17,9 @@ image:
 
 $E \in \mathscr{F}$ 일 때, 적분을 정의하기 위해
 
-$$\mathscr{F}_E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu|_{\mathscr{F}_E}$$
+$$\mathscr{F} _E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu|_ {\mathscr{F} _E}$$
 
-로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F}_E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
+로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F} _E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
 
 $$\int_E f \,d{\mu} = \int f \chi _E \,d{\mu}$$
 
@@ -43,13 +43,13 @@ $$\int \chi_A \,d{\mu} = \mu(A)$$
 
 다음으로 양의 값을 갖는 measurable simple function에 대해 정의합니다. $f = f^+ - f^-$ 에서 $f^+, f^-$ 모두 양의 값을 갖기 때문에 양의 값에 대해 먼저 정의합니다.
 
-**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right)_{k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right)_{k=1}^n$을 잡아
+**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right) _ {k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right) _ {k=1}^n$을 잡아
 
-$$f(x) = \sum_{k=1}^n a_k \chi_{A_k}$$
+$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k}$$
 
 와 같이 표현할 수 있다. 이제
 
-$$\int f\,d{\mu} = \sum_{k=1}^n a_k \mu(A_k) \in [0, \infty]$$
+$$\int f\,d{\mu} = \sum_ {k=1}^n a_k \mu(A_k) \in [0, \infty]$$
 
 로 정의한다.
 
@@ -61,17 +61,17 @@ Well-definedness를 증명하기 위해 임의의 linear combination을 잡아�
 
 **증명.** $f$가 다음과 같이 두 가지 방법으로 표현된다고 하자.
 
-$$f(x) = \sum_{k=1}^n a_k \chi_{A_k} = \sum_{i=1}^m b_i \chi_{B_i}.$$
+$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k} = \sum_ {i=1}^m b_i \chi_ {B_i}.$$
 
-여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C_{k, i} = A_k \cap B_i$ 로 두면
+여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C_ {k, i} = A_k \cap B_i$ 로 두면
 
-$$\sum_{k=1}^n a_k \mu(A_k) = \sum_{k=1}^n a_k \mu\left( A_k \cap \bigcup_{i=1}^m B_i \right) = \sum_{k=1}^n \sum_{i=1}^m a_k \mu(C_{k, i}),$$
+$$\sum_ {k=1}^n a_k \mu(A_k) = \sum_ {k=1}^n a_k \mu\left( A_k \cap \bigcup_ {i=1}^m B_i \right) = \sum_ {k=1}^n \sum_ {i=1}^m a_k \mu(C_ {k, i}),$$
 
-$$\sum_{i=1}^m b_i \mu(B_i) = \sum_{i=1}^{m} b_i \mu\left( B_i \cap \bigcup_{k=1}^n A_k \right)= \sum_{i=1}^m \sum_{k=1}^n b_i \mu(C_{k, i})$$
+$$\sum_ {i=1}^m b_i \mu(B_i) = \sum_ {i=1}^{m} b_i \mu\left( B_i \cap \bigcup_ {k=1}^n A_k \right)= \sum_ {i=1}^m \sum_ {k=1}^n b_i \mu(C_ {k, i})$$
 
-이다. 이 때 $C_{k, i} \neq \varnothing$ 이면 $x \in C_{k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C_{k, i} = \varnothing$ 이면 $\mu(C_{k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C_{k, i}) = a_k \mu(C_{k, i})$ 임을 알 수 있다.[^1] 따라서
+이다. 이 때 $C_ {k, i} \neq \varnothing$ 이면 $x \in C_ {k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C_ {k, i} = \varnothing$ 이면 $\mu(C_ {k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C_ {k, i}) = a_k \mu(C_ {k, i})$ 임을 알 수 있다.[^1] 따라서
 
-$$\int f \,d{\mu }= \sum_{k=1}^n a_k \mu(A_k) = \sum_{i=1}^m b_i \mu(B_i)$$
+$$\int f \,d{\mu }= \sum_ {k=1}^n a_k \mu(A_k) = \sum_ {i=1}^m b_i \mu(B_i)$$
 
 가 되어 적분값은 유일하고 위 정의가 well-defined임을 알 수 있다.
 
@@ -87,11 +87,11 @@ $$\int \left( af + bg \right) \,d{\mu} = a \int f \,d{\mu} + b \int g \,d{\mu}$$
 
 **증명.** 위 Step 2와 동일하게
 
-$$f = \sum_{j=1}^m y_j \chi_{A_j}, \quad g = \sum_{k=1}^n z_k \chi_{B_k}$$
+$$f = \sum_ {j=1}^m y_j \chi_ {A_j}, \quad g = \sum_ {k=1}^n z_k \chi_ {B_k}$$
 
-로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C_{j, k} = A_j \cap B_k$ 로 정의하면
+로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C_ {j, k} = A_j \cap B_k$ 로 정의하면
 
-$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum_{j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum_{j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum_{j} \sum_k ay_j \mu(C_{j, k}) + \sum_k \sum_j b z_k \mu(C_{j, k}) \\                                            & = \sum_{j, k} (ay_j + bz_k) \mu(C_{j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum_ {j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum_ {j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum_ {j} \sum_k ay_j \mu(C_ {j, k}) + \sum_k \sum_j b z_k \mu(C_ {j, k}) \\                                            & = \sum_ {j, k} (ay_j + bz_k) \mu(C_ {j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
 
 이다.
 
@@ -123,7 +123,7 @@ $f$보다 작은 measurable simple function의 적분값 중 상한을 택하겠
 
 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 지난 번에 보였습니다. 이 $s_n$에 대하여 적분값을 계산해보면
 
-$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 임을 알 수 있습니다. 이제 $n \rightarrow\infty$ 일 때 우변이 곧 $\displaystyle\int f \,d{\mu}$ 이기를 기대합니다.
 

--- a/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
+++ b/_posts/Mathematics/Measure Theory/2023-02-13-lebesgue-integration.md
@@ -17,9 +17,9 @@ image:
 
 $E \in \mathscr{F}$ 일 때, 적분을 정의하기 위해
 
-$$\mathscr{F} _E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu|_ {\mathscr{F} _E}$$
+$$\mathscr{F}_ E = \lbrace A \cap E : A \in \mathscr{F}\rbrace, \quad \mu_E = \mu| _{\mathscr{F}_ E}$$
 
-로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F} _E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
+로 설정하고 $\int = \int_E$ 로 두어 ($X, \mathscr{F}_ E, \mu_E$) 위에서 적분을 정의할 수 있습니다. 그러나 굳이 이렇게 하지 않아도 됩니다. $\int = \int_X$ 로 두고
 
 $$\int_E f \,d{\mu} = \int f \chi _E \,d{\mu}$$
 
@@ -43,13 +43,13 @@ $$\int \chi_A \,d{\mu} = \mu(A)$$
 
 다음으로 양의 값을 갖는 measurable simple function에 대해 정의합니다. $f = f^+ - f^-$ 에서 $f^+, f^-$ 모두 양의 값을 갖기 때문에 양의 값에 대해 먼저 정의합니다.
 
-**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right) _ {k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right) _ {k=1}^n$을 잡아
+**(Step 2)** $f: X \rightarrow[0, \infty)$ 가 measurable simple function이라 하자. 그러면 $A_k \subseteq\mathscr{F}$ 이면서 쌍마다 서로소인 집합열 $\left( A_k \right) _{k=1}^n$과 $a_k \in [0, \infty)$ 인 수열 $\left( a_k \right) _{k=1}^n$을 잡아
 
-$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k}$$
+$$f(x) = \sum _{k=1}^n a_k \chi _{A_k}$$
 
 와 같이 표현할 수 있다. 이제
 
-$$\int f\,d{\mu} = \sum_ {k=1}^n a_k \mu(A_k) \in [0, \infty]$$
+$$\int f\,d{\mu} = \sum _{k=1}^n a_k \mu(A_k) \in [0, \infty]$$
 
 로 정의한다.
 
@@ -61,17 +61,17 @@ Well-definedness를 증명하기 위해 임의의 linear combination을 잡아�
 
 **증명.** $f$가 다음과 같이 두 가지 방법으로 표현된다고 하자.
 
-$$f(x) = \sum_ {k=1}^n a_k \chi_ {A_k} = \sum_ {i=1}^m b_i \chi_ {B_i}.$$
+$$f(x) = \sum _{k=1}^n a_k \chi _{A_k} = \sum _{i=1}^m b_i \chi _{B_i}.$$
 
-여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C_ {k, i} = A_k \cap B_i$ 로 두면
+여기서 $k = 1, \dots, n$, $i = 1, \dots, m$ 에 대하여 $0\leq a_k, b_i < \infty$ 이고 $A_k, B_i \in \mathscr{F}$ 이다. 여기서 $A_k, B_i$는 각각 쌍마다 서로소로, $X$의 분할이 된다. $C _{k, i} = A_k \cap B_i$ 로 두면
 
-$$\sum_ {k=1}^n a_k \mu(A_k) = \sum_ {k=1}^n a_k \mu\left( A_k \cap \bigcup_ {i=1}^m B_i \right) = \sum_ {k=1}^n \sum_ {i=1}^m a_k \mu(C_ {k, i}),$$
+$$\sum _{k=1}^n a_k \mu(A_k) = \sum _{k=1}^n a_k \mu\left( A_k \cap \bigcup _{i=1}^m B_i \right) = \sum _{k=1}^n \sum _{i=1}^m a_k \mu(C _{k, i}),$$
 
-$$\sum_ {i=1}^m b_i \mu(B_i) = \sum_ {i=1}^{m} b_i \mu\left( B_i \cap \bigcup_ {k=1}^n A_k \right)= \sum_ {i=1}^m \sum_ {k=1}^n b_i \mu(C_ {k, i})$$
+$$\sum _{i=1}^m b_i \mu(B_i) = \sum _{i=1}^{m} b_i \mu\left( B_i \cap \bigcup _{k=1}^n A_k \right)= \sum _{i=1}^m \sum _{k=1}^n b_i \mu(C _{k, i})$$
 
-이다. 이 때 $C_ {k, i} \neq \varnothing$ 이면 $x \in C_ {k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C_ {k, i} = \varnothing$ 이면 $\mu(C_ {k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C_ {k, i}) = a_k \mu(C_ {k, i})$ 임을 알 수 있다.[^1] 따라서
+이다. 이 때 $C _{k, i} \neq \varnothing$ 이면 $x \in C _{k, i}$ 에 대해 $f(x) = a_k = b_i$ 가 된다. 한편 $C _{k, i} = \varnothing$ 이면 $\mu(C _{k, i}) = 0$ 이다. 이로부터 모든 $k, i$에 대하여 $b_i \mu(C _{k, i}) = a_k \mu(C _{k, i})$ 임을 알 수 있다.[^1] 따라서
 
-$$\int f \,d{\mu }= \sum_ {k=1}^n a_k \mu(A_k) = \sum_ {i=1}^m b_i \mu(B_i)$$
+$$\int f \,d{\mu }= \sum _{k=1}^n a_k \mu(A_k) = \sum _{i=1}^m b_i \mu(B_i)$$
 
 가 되어 적분값은 유일하고 위 정의가 well-defined임을 알 수 있다.
 
@@ -87,11 +87,11 @@ $$\int \left( af + bg \right) \,d{\mu} = a \int f \,d{\mu} + b \int g \,d{\mu}$$
 
 **증명.** 위 Step 2와 동일하게
 
-$$f = \sum_ {j=1}^m y_j \chi_ {A_j}, \quad g = \sum_ {k=1}^n z_k \chi_ {B_k}$$
+$$f = \sum _{j=1}^m y_j \chi _{A_j}, \quad g = \sum _{k=1}^n z_k \chi _{B_k}$$
 
-로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C_ {j, k} = A_j \cap B_k$ 로 정의하면
+로 둘 수 있다. 여기서 $A_j, B_k$는 $X$의 분할이고 $y_j, z_k \geq 0$ 이다. 마찬가지로 $C _{j, k} = A_j \cap B_k$ 로 정의하면
 
-$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum_ {j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum_ {j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum_ {j} \sum_k ay_j \mu(C_ {j, k}) + \sum_k \sum_j b z_k \mu(C_ {j, k}) \\                                            & = \sum_ {j, k} (ay_j + bz_k) \mu(C_ {j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        a \int f \,d{\mu} + b \int g \,d{\mu} & = \sum _{j} ay_j \mu(A_j) + \sum_k b z_k \mu(B_k) \\                                            & = \sum _{j} ay_j \sum_k \mu(A_j \cap B_k) + \sum_k b z_k \sum_j \mu(B_k \cap A_j) \\                                            & = \sum _{j} \sum_k ay_j \mu(C _{j, k}) + \sum_k \sum_j b z_k \mu(C _{j, k}) \\                                            & = \sum _{j, k} (ay_j + bz_k) \mu(C _{j, k}) = \int \left( af + bg \right) \,d{\mu}    \end{aligned}$$
 
 이다.
 
@@ -123,7 +123,7 @@ $f$보다 작은 measurable simple function의 적분값 중 상한을 택하겠
 
 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 지난 번에 보였습니다. 이 $s_n$에 대하여 적분값을 계산해보면
 
-$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum _{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 임을 알 수 있습니다. 이제 $n \rightarrow\infty$ 일 때 우변이 곧 $\displaystyle\int f \,d{\mu}$ 이기를 기대합니다.
 

--- a/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
+++ b/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
@@ -85,7 +85,7 @@ $$\infty = \int \chi_{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 지난 번에 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 보였고, 이 $s_n$에 대하여 적분값을 계산하여
 
-$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace  \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace )$$
+$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 라는 결과까지 얻었습니다. 그런데 여기서
 
@@ -189,11 +189,10 @@ $$\int_E \limsup_{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_{n \rightarrow\
 
 	$$\int_A \lvert f \rvert \,d{\mu} \leq \int_E \lvert f \rvert\,d{\mu} < \infty.$$
 
-6. 만약 measure가 0인 집합에서 적분을 하면 어떻게 될까요? $\mu(E) = 0$ 라 하고, measurable function $f$를 적분해 보겠습니다. 여기서 $\min\lbrace \lvert f \rvert, n\rbrace \chi_E$ 도 measurable이며 $n \rightarrow\infty$ 일 때 $\min\lbrace \lvert f \rvert, n\rbrace \chi_E \nearrow \lvert f \rvert\chi_E$ 임을 이용합니다. 마지막으로 단조 수렴 정리를 적용하면
+6. 만약 measure가 0인 집합에서 적분을 하면 어떻게 될까요? $\mu(E) = 0$ 라 하고, measurable function $f$를 적분해 보겠습니다. 여기서 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E$ 도 measurable이며 $n \rightarrow\infty$ 일 때 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E \nearrow \lvert f \rvert\chi_E$ 임을 이용합니다. 마지막으로 단조 수렴 정리를 적용하면
 
-	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_{n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace  \,d{\mu} \\                    &\leq \lim_{n \rightarrow\infty} \int_E n \,d{\mu} = \lim_{n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
+	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_{n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim_{n \rightarrow\infty} \int_E n \,d{\mu} = \lim_{n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
 
 	임을 얻습니다. 따라서 $f \in \mathcal{L}^{1}(E, \mu)$ 이고, $\displaystyle\int_E f \,d{\mu} = 0$ 가 되어 적분값이 0임을 알 수 있습니다. 즉, measure가 0인 집합 위에서 적분하면 그 결과는 0이 됩니다.[^1]
 
 [^1]: 편의상 $0\cdot\infty = 0$ 으로 정의했기 때문에 $f \equiv \infty$ 인 경우에도 성립합니다.
-

--- a/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
+++ b/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
@@ -19,13 +19,13 @@ image:
 
 ![mt-06.png](../../../assets/img/posts/mt-06.png)
 
-**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f _{n+1}(x)$ 라 하자.
+**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f_ {n+1}(x)$ 라 하자.
 
-$$\lim _{n\rightarrow\infty} f_n(x) = \sup _{n} f_n(x) = f(x)$$
+$$\lim_ {n\rightarrow\infty} f_n(x) = \sup_ {n} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\int f \,d{\mu} = \lim _{n\rightarrow\infty} \int f_n \,d{\mu} = \sup _{n \in \mathbb{N}} \int f_n \,d{\mu}$$
+$$\int f \,d{\mu} = \lim_ {n\rightarrow\infty} \int f_n \,d{\mu} = \sup_ {n \in \mathbb{N}} \int f_n \,d{\mu}$$
 
 이다.
 
@@ -41,43 +41,43 @@ $$\sup_n \int f_n \,d{\mu} \leq \int f \,d{\mu}.$$
 
 $$E_n = \lbrace x \in X : f_n(x) \geq cs(x)\rbrace$$
 
-으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E _{n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup _{n=1}^\infty E_n = X$ 이다.
+으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E_ {n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup_ {n=1}^\infty E_n = X$ 이다.
 
-충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi _{E_n} \geq cs \chi _{E_n}$ 이므로
+충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi_ {E_n} \geq cs \chi_ {E_n}$ 이므로
 
-$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi _{E_n} \,d{\mu} \geq c\int s \chi _{E_n} \,d{\mu},$$
+$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi_ {E_n} \,d{\mu} \geq c\int s \chi_ {E_n} \,d{\mu},$$
 
-이고 여기서 $s, \chi _{E_n}$는 simple function이다. 그러므로 $s = \sum _{k=0}^m y_k \chi _{A_k}$ 라고 적으면
+이고 여기서 $s, \chi_ {E_n}$는 simple function이다. 그러므로 $s = \sum_ {k=0}^m y_k \chi_ {A_k}$ 라고 적으면
 
-$$s\chi _{E_n} = \sum _{k=0}^m y_k \chi _{A_k\cap E_n} \implies \int s \chi _{E_n} \,d{\mu} = \sum _{k=0}^m y_k \mu(A_k\cap E_n)$$
+$$s\chi_ {E_n} = \sum_ {k=0}^m y_k \chi_ {A_k\cap E_n} \implies \int s \chi_ {E_n} \,d{\mu} = \sum_ {k=0}^m y_k \mu(A_k\cap E_n)$$
 
 이다. $n\rightarrow\infty$ 일 때 $A_k\cap E_n \nearrow A_k$ 이므로, continuity of measure를 사용해 $\mu(A_k \cap E_n) \nearrow \mu(A_k)$ 를 얻고
 
-$$\lim _{n\rightarrow\infty} \int s \chi _{E_n}\,d{\mu} = \int s \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int s \chi_ {E_n}\,d{\mu} = \int s \,d{\mu}$$
 
 임도 알 수 있다. 이제 ($\star$)를 이용하면
 
-$$\lim _{n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
 
 이므로, $c \nearrow 1$ 로 두고 $0\leq s\leq f$ 에 대하여 $\sup$을 취하면
 
-$$\lim _{n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup _{0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup_ {0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
 
 가 되어 원하는 결과를 얻는다.
 
-**참고.** 만약 부등식 $0 \leq f_n \leq f _{n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
+**참고.** 만약 부등식 $0 \leq f_n \leq f_ {n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
 
-$$0 \leq f_n \chi_E \leq f _{n+1} \chi_E \nearrow f \chi_E.$$
+$$0 \leq f_n \chi_E \leq f_ {n+1} \chi_E \nearrow f \chi_E.$$
 
 그러므로 단조 수렴 정리가 $E$에서도 성립함을 알 수 있다.
 
-> $E$에서 $0\leq f_n \leq f _{n+1} \nearrow f$ 이면 $\displaystyle\lim _{n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
+> $E$에서 $0\leq f_n \leq f_ {n+1} \nearrow f$ 이면 $\displaystyle\lim_ {n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
 
-**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi _{[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi _{[n, \infty)} \searrow 0$ 입니다.
+**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi_ {[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi_ {[n, \infty)} \searrow 0$ 입니다.
 
 그러면 Lebesgue measure $m$에 대하여
 
-$$\infty = \int \chi _{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
+$$\infty = \int \chi_ {[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 이 되어 단조 수렴 정리가 성립하지 않음을 확인할 수 있습니다.
 
@@ -85,15 +85,15 @@ $$\infty = \int \chi _{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 지난 번에 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 보였고, 이 $s_n$에 대하여 적분값을 계산하여
 
-$$\int_E s_n \,d{\mu} = \sum _{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 라는 결과까지 얻었습니다. 그런데 여기서
 
-$$f(x) = \displaystyle\lim _{n\rightarrow\infty} s_n(x)$$
+$$f(x) = \displaystyle\lim_ {n\rightarrow\infty} s_n(x)$$
 
 이기 때문에, 단조 수렴 정리에 의해
 
-$$\int_E f \,d{\mu} = \lim _{n\rightarrow\infty} \int_E s_n \,d{\mu}$$
+$$\int_E f \,d{\mu} = \lim_ {n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 가 성립하여 기대했던 결과를 얻었습니다. 지난 번 설명한 것처럼, 이는 곧 르벡 적분은 치역을 잘게 잘라 넓이를 계산한 것으로 이해할 수 있다는 의미가 됩니다.
 
@@ -105,7 +105,7 @@ $$\int_E f \,d{\mu} = \lim _{n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 $$\int_E \left( \alpha f + \beta g \right) \,d{\mu} = \alpha \int_E f \,d{\mu} + \beta \int_E g\,d{\mu}.$$
 
-**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f _{n+1} \nearrow f$, $0 \leq g_n \leq g _{n+1} \nearrow g$ 으로 잡는다.
+**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f_ {n+1} \nearrow f$, $0 \leq g_n \leq g_ {n+1} \nearrow g$ 으로 잡는다.
 
 그러면 $\alpha f_n + \beta g_n \nearrow \alpha f + \beta g$ 이고 $\alpha f_n + \beta g_n$ 은 단조증가하는 measurable simple 함수열이다. 따라서 단조 수렴 정리에 의해
 
@@ -115,11 +115,11 @@ $$\int_E \left( \alpha f_n + \beta g_n \right) \,d{\mu} = \alpha \int_E f_n \,d{
 
 이와 비슷한 방법을 급수에도 적용할 수 있습니다.
 
-**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum _{n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
+**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum_ {n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
 
-$$\int_E \sum _{n=1}^\infty f_n \,d{\mu} = \sum _{n=1}^\infty \int_E f_n \,d{\mu}.$$
+$$\int_E \sum_ {n=1}^\infty f_n \,d{\mu} = \sum_ {n=1}^\infty \int_E f_n \,d{\mu}.$$
 
-**증명.** $\sum _{n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
+**증명.** $\sum_ {n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
 
 ## Fatou's Lemma
 
@@ -127,15 +127,15 @@ $$\int_E \sum _{n=1}^\infty f_n \,d{\mu} = \sum _{n=1}^\infty \int_E f_n \,d{\mu
 
 **정리.** (Fatou) $f_n \geq 0$ 가 measurable이고 $E$가 measurable이라 하자. 다음이 성립한다.
 
-$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf _{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
-**증명.** $g_n = \displaystyle\inf _{k \geq n} f_k$ 으로 두면 $\displaystyle\lim _{n \rightarrow\infty} g_n = \liminf _{n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
+**증명.** $g_n = \displaystyle\inf_ {k \geq n} f_k$ 으로 두면 $\displaystyle\lim_ {n \rightarrow\infty} g_n = \liminf_ {n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
 
-$$\int_E g_n \,d{\mu} \leq \inf _{k\geq n} \int_E f_k \,d{\mu}$$
+$$\int_E g_n \,d{\mu} \leq \inf_ {k\geq n} \int_E f_k \,d{\mu}$$
 
 이다. 여기서 $n \rightarrow\infty$ 로 두면
 
-$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} = \lim _{n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim _{n \rightarrow\infty} \inf _{k \geq n}\int_E f_k \,d{\mu} = \liminf _{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} = \lim_ {n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim_ {n \rightarrow\infty} \inf_ {k \geq n}\int_E f_k \,d{\mu} = \liminf_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
 이 된다. 여기서 첫 번째 등호는 단조 수렴 정리에 의해 성립한다.
 
@@ -143,9 +143,9 @@ $$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} = \lim _{n \rightarrow\infty
 
 **참고.** 왠지 위와 비슷한 결론이 $\limsup$에 대해서도 성립해야 할 것 같습니다. 구체적으로,
 
-$$\int_E \limsup _{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup _{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \limsup_ {n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
-일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi _{[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
+일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi_ {[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
 
 ## Properties of the Lebesgue Integral
 
@@ -191,7 +191,7 @@ $$\int_E \limsup _{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup _{n \rightarro
 
 6. 만약 measure가 0인 집합에서 적분을 하면 어떻게 될까요? $\mu(E) = 0$ 라 하고, measurable function $f$를 적분해 보겠습니다. 여기서 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E$ 도 measurable이며 $n \rightarrow\infty$ 일 때 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E \nearrow \lvert f \rvert\chi_E$ 임을 이용합니다. 마지막으로 단조 수렴 정리를 적용하면
 
-	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim _{n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim _{n \rightarrow\infty} \int_E n \,d{\mu} = \lim _{n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
+	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_ {n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim_ {n \rightarrow\infty} \int_E n \,d{\mu} = \lim_ {n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
 
 	임을 얻습니다. 따라서 $f \in \mathcal{L}^{1}(E, \mu)$ 이고, $\displaystyle\int_E f \,d{\mu} = 0$ 가 되어 적분값이 0임을 알 수 있습니다. 즉, measure가 0인 집합 위에서 적분하면 그 결과는 0이 됩니다.[^1]
 

--- a/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
+++ b/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
@@ -19,13 +19,13 @@ image:
 
 ![mt-06.png](../../../assets/img/posts/mt-06.png)
 
-**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f_{n+1}(x)$ 라 하자.
+**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f_ {n+1}(x)$ 라 하자.
 
-$$\lim_{n\rightarrow\infty} f_n(x) = \sup_{n} f_n(x) = f(x)$$
+$$\lim_ {n\rightarrow\infty} f_n(x) = \sup_ {n} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\int f \,d{\mu} = \lim_{n\rightarrow\infty} \int f_n \,d{\mu} = \sup_{n \in \mathbb{N}} \int f_n \,d{\mu}$$
+$$\int f \,d{\mu} = \lim_ {n\rightarrow\infty} \int f_n \,d{\mu} = \sup_ {n \in \mathbb{N}} \int f_n \,d{\mu}$$
 
 이다.
 
@@ -41,43 +41,43 @@ $$\sup_n \int f_n \,d{\mu} \leq \int f \,d{\mu}.$$
 
 $$E_n = \lbrace x \in X : f_n(x) \geq cs(x)\rbrace$$
 
-으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E_{n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup_{n=1}^\infty E_n = X$ 이다.
+으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E_ {n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup_ {n=1}^\infty E_n = X$ 이다.
 
-충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi_{E_n} \geq cs \chi_{E_n}$ 이므로
+충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi_ {E_n} \geq cs \chi_ {E_n}$ 이므로
 
-$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi_{E_n} \,d{\mu} \geq c\int s \chi_{E_n} \,d{\mu},$$
+$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi_ {E_n} \,d{\mu} \geq c\int s \chi_ {E_n} \,d{\mu},$$
 
-이고 여기서 $s, \chi_{E_n}$는 simple function이다. 그러므로 $s = \sum_{k=0}^m y_k \chi_{A_k}$ 라고 적으면
+이고 여기서 $s, \chi_ {E_n}$는 simple function이다. 그러므로 $s = \sum_ {k=0}^m y_k \chi_ {A_k}$ 라고 적으면
 
-$$s\chi_{E_n} = \sum_{k=0}^m y_k \chi_{A_k\cap E_n} \implies \int s \chi_{E_n} \,d{\mu} = \sum_{k=0}^m y_k \mu(A_k\cap E_n)$$
+$$s\chi_ {E_n} = \sum_ {k=0}^m y_k \chi_ {A_k\cap E_n} \implies \int s \chi_ {E_n} \,d{\mu} = \sum_ {k=0}^m y_k \mu(A_k\cap E_n)$$
 
 이다. $n\rightarrow\infty$ 일 때 $A_k\cap E_n \nearrow A_k$ 이므로, continuity of measure를 사용해 $\mu(A_k \cap E_n) \nearrow \mu(A_k)$ 를 얻고
 
-$$\lim_{n\rightarrow\infty} \int s \chi_{E_n}\,d{\mu} = \int s \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int s \chi_ {E_n}\,d{\mu} = \int s \,d{\mu}$$
 
 임도 알 수 있다. 이제 ($\star$)를 이용하면
 
-$$\lim_{n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
 
 이므로, $c \nearrow 1$ 로 두고 $0\leq s\leq f$ 에 대하여 $\sup$을 취하면
 
-$$\lim_{n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup_{0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
+$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup_ {0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
 
 가 되어 원하는 결과를 얻는다.
 
-**참고.** 만약 부등식 $0 \leq f_n \leq f_{n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
+**참고.** 만약 부등식 $0 \leq f_n \leq f_ {n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
 
-$$0 \leq f_n \chi_E \leq f_{n+1} \chi_E \nearrow f \chi_E.$$
+$$0 \leq f_n \chi_E \leq f_ {n+1} \chi_E \nearrow f \chi_E.$$
 
 그러므로 단조 수렴 정리가 $E$에서도 성립함을 알 수 있다.
 
-> $E$에서 $0\leq f_n \leq f_{n+1} \nearrow f$ 이면 $\displaystyle\lim_{n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
+> $E$에서 $0\leq f_n \leq f_ {n+1} \nearrow f$ 이면 $\displaystyle\lim_ {n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
 
-**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi_{[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi_{[n, \infty)} \searrow 0$ 입니다.
+**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi_ {[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi_ {[n, \infty)} \searrow 0$ 입니다.
 
 그러면 Lebesgue measure $m$에 대하여
 
-$$\infty = \int \chi_{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
+$$\infty = \int \chi_ {[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 이 되어 단조 수렴 정리가 성립하지 않음을 확인할 수 있습니다.
 
@@ -85,15 +85,15 @@ $$\infty = \int \chi_{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 지난 번에 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 보였고, 이 $s_n$에 대하여 적분값을 계산하여
 
-$$\int_E s_n \,d{\mu} = \sum_{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 라는 결과까지 얻었습니다. 그런데 여기서
 
-$$f(x) = \displaystyle\lim_{n\rightarrow\infty} s_n(x)$$
+$$f(x) = \displaystyle\lim_ {n\rightarrow\infty} s_n(x)$$
 
 이기 때문에, 단조 수렴 정리에 의해
 
-$$\int_E f \,d{\mu} = \lim_{n\rightarrow\infty} \int_E s_n \,d{\mu}$$
+$$\int_E f \,d{\mu} = \lim_ {n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 가 성립하여 기대했던 결과를 얻었습니다. 지난 번 설명한 것처럼, 이는 곧 르벡 적분은 치역을 잘게 잘라 넓이를 계산한 것으로 이해할 수 있다는 의미가 됩니다.
 
@@ -105,7 +105,7 @@ $$\int_E f \,d{\mu} = \lim_{n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 $$\int_E \left( \alpha f + \beta g \right) \,d{\mu} = \alpha \int_E f \,d{\mu} + \beta \int_E g\,d{\mu}.$$
 
-**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f_{n+1} \nearrow f$, $0 \leq g_n \leq g_{n+1} \nearrow g$ 으로 잡는다.
+**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f_ {n+1} \nearrow f$, $0 \leq g_n \leq g_ {n+1} \nearrow g$ 으로 잡는다.
 
 그러면 $\alpha f_n + \beta g_n \nearrow \alpha f + \beta g$ 이고 $\alpha f_n + \beta g_n$ 은 단조증가하는 measurable simple 함수열이다. 따라서 단조 수렴 정리에 의해
 
@@ -115,11 +115,11 @@ $$\int_E \left( \alpha f_n + \beta g_n \right) \,d{\mu} = \alpha \int_E f_n \,d{
 
 이와 비슷한 방법을 급수에도 적용할 수 있습니다.
 
-**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum_{n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
+**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum_ {n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
 
-$$\int_E \sum_{n=1}^\infty f_n \,d{\mu} = \sum_{n=1}^\infty \int_E f_n \,d{\mu}.$$
+$$\int_E \sum_ {n=1}^\infty f_n \,d{\mu} = \sum_ {n=1}^\infty \int_E f_n \,d{\mu}.$$
 
-**증명.** $\sum_{n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
+**증명.** $\sum_ {n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
 
 ## Fatou's Lemma
 
@@ -127,15 +127,15 @@ $$\int_E \sum_{n=1}^\infty f_n \,d{\mu} = \sum_{n=1}^\infty \int_E f_n \,d{\mu}.
 
 **정리.** (Fatou) $f_n \geq 0$ 가 measurable이고 $E$가 measurable이라 하자. 다음이 성립한다.
 
-$$\int_E \liminf_{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
-**증명.** $g_n = \displaystyle\inf_{k \geq n} f_k$ 으로 두면 $\displaystyle\lim_{n \rightarrow\infty} g_n = \liminf_{n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
+**증명.** $g_n = \displaystyle\inf_ {k \geq n} f_k$ 으로 두면 $\displaystyle\lim_ {n \rightarrow\infty} g_n = \liminf_ {n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
 
-$$\int_E g_n \,d{\mu} \leq \inf_{k\geq n} \int_E f_k \,d{\mu}$$
+$$\int_E g_n \,d{\mu} \leq \inf_ {k\geq n} \int_E f_k \,d{\mu}$$
 
 이다. 여기서 $n \rightarrow\infty$ 로 두면
 
-$$\int_E \liminf_{n\rightarrow\infty} f_n \,d{\mu} = \lim_{n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim_{n \rightarrow\infty} \inf_{k \geq n}\int_E f_k \,d{\mu} = \liminf_{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} = \lim_ {n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim_ {n \rightarrow\infty} \inf_ {k \geq n}\int_E f_k \,d{\mu} = \liminf_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
 이 된다. 여기서 첫 번째 등호는 단조 수렴 정리에 의해 성립한다.
 
@@ -143,9 +143,9 @@ $$\int_E \liminf_{n\rightarrow\infty} f_n \,d{\mu} = \lim_{n \rightarrow\infty} 
 
 **참고.** 왠지 위와 비슷한 결론이 $\limsup$에 대해서도 성립해야 할 것 같습니다. 구체적으로,
 
-$$\int_E \limsup_{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \limsup_ {n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
-일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi_{[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
+일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi_ {[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
 
 ## Properties of the Lebesgue Integral
 
@@ -191,7 +191,7 @@ $$\int_E \limsup_{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_{n \rightarrow\
 
 6. 만약 measure가 0인 집합에서 적분을 하면 어떻게 될까요? $\mu(E) = 0$ 라 하고, measurable function $f$를 적분해 보겠습니다. 여기서 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E$ 도 measurable이며 $n \rightarrow\infty$ 일 때 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E \nearrow \lvert f \rvert\chi_E$ 임을 이용합니다. 마지막으로 단조 수렴 정리를 적용하면
 
-	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_{n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim_{n \rightarrow\infty} \int_E n \,d{\mu} = \lim_{n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
+	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_ {n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim_ {n \rightarrow\infty} \int_E n \,d{\mu} = \lim_ {n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
 
 	임을 얻습니다. 따라서 $f \in \mathcal{L}^{1}(E, \mu)$ 이고, $\displaystyle\int_E f \,d{\mu} = 0$ 가 되어 적분값이 0임을 알 수 있습니다. 즉, measure가 0인 집합 위에서 적분하면 그 결과는 0이 됩니다.[^1]
 

--- a/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
+++ b/_posts/Mathematics/Measure Theory/2023-03-25-convergence-theorems.md
@@ -19,13 +19,13 @@ image:
 
 ![mt-06.png](../../../assets/img/posts/mt-06.png)
 
-**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f_ {n+1}(x)$ 라 하자.
+**정리.** (단조 수렴 정리) $f_n: X \rightarrow[0, \infty]$ 가 measurable이고 모든 $x \in X$ 에 대하여 $f_n(x) \leq f _{n+1}(x)$ 라 하자.
 
-$$\lim_ {n\rightarrow\infty} f_n(x) = \sup_ {n} f_n(x) = f(x)$$
+$$\lim _{n\rightarrow\infty} f_n(x) = \sup _{n} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\int f \,d{\mu} = \lim_ {n\rightarrow\infty} \int f_n \,d{\mu} = \sup_ {n \in \mathbb{N}} \int f_n \,d{\mu}$$
+$$\int f \,d{\mu} = \lim _{n\rightarrow\infty} \int f_n \,d{\mu} = \sup _{n \in \mathbb{N}} \int f_n \,d{\mu}$$
 
 이다.
 
@@ -41,43 +41,43 @@ $$\sup_n \int f_n \,d{\mu} \leq \int f \,d{\mu}.$$
 
 $$E_n = \lbrace x \in X : f_n(x) \geq cs(x)\rbrace$$
 
-으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E_ {n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup_ {n=1}^\infty E_n = X$ 이다.
+으로 두면, $f_n(x) - cs(x)$ 가 measurable function이므로 $E_n$ 또한 measurable이다. 여기서 $f_n$이 증가하므로 $E_n\subseteq E _{n+1} \subseteq\cdots$ 임을 알 수 있고 $f_n \rightarrow f$ 이므로 $\bigcup _{n=1}^\infty E_n = X$ 이다.
 
-충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi_ {E_n} \geq cs \chi_ {E_n}$ 이므로
+충분히 큰 $N \in \mathbb{N}$ 에 대하여 $n \geq N$ 일 때, 모든 $x$에 대하여 $f(x) \geq f_n(x) > cs(x)$ 가 되게 할 수 있다. 그리고 $f_n \geq f_n \chi _{E_n} \geq cs \chi _{E_n}$ 이므로
 
-$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi_ {E_n} \,d{\mu} \geq c\int s \chi_ {E_n} \,d{\mu},$$
+$$\tag{\(\star\)}    \int f_n \,d{\mu} \geq \int f_n \chi _{E_n} \,d{\mu} \geq c\int s \chi _{E_n} \,d{\mu},$$
 
-이고 여기서 $s, \chi_ {E_n}$는 simple function이다. 그러므로 $s = \sum_ {k=0}^m y_k \chi_ {A_k}$ 라고 적으면
+이고 여기서 $s, \chi _{E_n}$는 simple function이다. 그러므로 $s = \sum _{k=0}^m y_k \chi _{A_k}$ 라고 적으면
 
-$$s\chi_ {E_n} = \sum_ {k=0}^m y_k \chi_ {A_k\cap E_n} \implies \int s \chi_ {E_n} \,d{\mu} = \sum_ {k=0}^m y_k \mu(A_k\cap E_n)$$
+$$s\chi _{E_n} = \sum _{k=0}^m y_k \chi _{A_k\cap E_n} \implies \int s \chi _{E_n} \,d{\mu} = \sum _{k=0}^m y_k \mu(A_k\cap E_n)$$
 
 이다. $n\rightarrow\infty$ 일 때 $A_k\cap E_n \nearrow A_k$ 이므로, continuity of measure를 사용해 $\mu(A_k \cap E_n) \nearrow \mu(A_k)$ 를 얻고
 
-$$\lim_ {n\rightarrow\infty} \int s \chi_ {E_n}\,d{\mu} = \int s \,d{\mu}$$
+$$\lim _{n\rightarrow\infty} \int s \chi _{E_n}\,d{\mu} = \int s \,d{\mu}$$
 
 임도 알 수 있다. 이제 ($\star$)를 이용하면
 
-$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
+$$\lim _{n\rightarrow\infty} \int f_n \,d{\mu} \geq c\int s \,d{\mu}$$
 
 이므로, $c \nearrow 1$ 로 두고 $0\leq s\leq f$ 에 대하여 $\sup$을 취하면
 
-$$\lim_ {n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup_ {0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
+$$\lim _{n\rightarrow\infty} \int f_n \,d{\mu} \geq \sup _{0\leq s\leq f} \int s \,d{\mu} = \int f \,d{\mu}$$
 
 가 되어 원하는 결과를 얻는다.
 
-**참고.** 만약 부등식 $0 \leq f_n \leq f_ {n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
+**참고.** 만약 부등식 $0 \leq f_n \leq f _{n+1}$ 이 정의역 전체가 아닌 정의역의 부분집합 $E$에서만 성립한다고 하면, 다음과 같이 생각할 수 있다.
 
-$$0 \leq f_n \chi_E \leq f_ {n+1} \chi_E \nearrow f \chi_E.$$
+$$0 \leq f_n \chi_E \leq f _{n+1} \chi_E \nearrow f \chi_E.$$
 
 그러므로 단조 수렴 정리가 $E$에서도 성립함을 알 수 있다.
 
-> $E$에서 $0\leq f_n \leq f_ {n+1} \nearrow f$ 이면 $\displaystyle\lim_ {n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
+> $E$에서 $0\leq f_n \leq f _{n+1} \nearrow f$ 이면 $\displaystyle\lim _{n\rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}$.
 
-**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi_ {[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi_ {[n, \infty)} \searrow 0$ 입니다.
+**참고.** 함수열 $f_n$이 증가하는 경우에만 정리가 성립합니다. 감소하는 경우에는 반례로 함수 $f_n = \chi _{[n, \infty)}$ 를 생각할 수 있습니다. 그러면 $n \rightarrow\infty$ 일 때 $\chi _{[n, \infty)} \searrow 0$ 입니다.
 
 그러면 Lebesgue measure $m$에 대하여
 
-$$\infty = \int \chi_ {[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
+$$\infty = \int \chi _{[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 이 되어 단조 수렴 정리가 성립하지 않음을 확인할 수 있습니다.
 
@@ -85,15 +85,15 @@ $$\infty = \int \chi_ {[n, \infty)} \,d{m} \neq \int 0 \,d{m} = 0$$
 
 지난 번에 $f \geq 0$ 가 measurable이면 증가하는 measurable simple 함수열 $s_n$이 존재함을 보였고, 이 $s_n$에 대하여 적분값을 계산하여
 
-$$\int_E s_n \,d{\mu} = \sum_ {i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
+$$\int_E s_n \,d{\mu} = \sum _{i=1}^{n2^n} \frac{i - 1}{2^n}\mu\left( \left\lbrace x \in E : \frac{i-1}{2^n} \leq f(x) \leq \frac{i}{2^n}\right\rbrace \right) + n\mu(\lbrace x \in E : f(x)\geq n\rbrace)$$
 
 라는 결과까지 얻었습니다. 그런데 여기서
 
-$$f(x) = \displaystyle\lim_ {n\rightarrow\infty} s_n(x)$$
+$$f(x) = \displaystyle\lim _{n\rightarrow\infty} s_n(x)$$
 
 이기 때문에, 단조 수렴 정리에 의해
 
-$$\int_E f \,d{\mu} = \lim_ {n\rightarrow\infty} \int_E s_n \,d{\mu}$$
+$$\int_E f \,d{\mu} = \lim _{n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 가 성립하여 기대했던 결과를 얻었습니다. 지난 번 설명한 것처럼, 이는 곧 르벡 적분은 치역을 잘게 잘라 넓이를 계산한 것으로 이해할 수 있다는 의미가 됩니다.
 
@@ -105,7 +105,7 @@ $$\int_E f \,d{\mu} = \lim_ {n\rightarrow\infty} \int_E s_n \,d{\mu}$$
 
 $$\int_E \left( \alpha f + \beta g \right) \,d{\mu} = \alpha \int_E f \,d{\mu} + \beta \int_E g\,d{\mu}.$$
 
-**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f_ {n+1} \nearrow f$, $0 \leq g_n \leq g_ {n+1} \nearrow g$ 으로 잡는다.
+**증명.** Measurable function은 measurable simple function으로 근사할 수 있고, $f, g \geq 0$ 이므로 단조증가하도록 잡을 수 있다. 그러므로 measurable simple function $f_n$, $g_n$에 대하여 $0 \leq f_n \leq f _{n+1} \nearrow f$, $0 \leq g_n \leq g _{n+1} \nearrow g$ 으로 잡는다.
 
 그러면 $\alpha f_n + \beta g_n \nearrow \alpha f + \beta g$ 이고 $\alpha f_n + \beta g_n$ 은 단조증가하는 measurable simple 함수열이다. 따라서 단조 수렴 정리에 의해
 
@@ -115,11 +115,11 @@ $$\int_E \left( \alpha f_n + \beta g_n \right) \,d{\mu} = \alpha \int_E f_n \,d{
 
 이와 비슷한 방법을 급수에도 적용할 수 있습니다.
 
-**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum_ {n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
+**정리.** Measurable function $f_n: X \rightarrow[0, \infty]$ 에 대하여 $\sum _{n=1}^\infty f_n$는 measurable이고, 단조 수렴 정리에 의해 다음이 성립한다.
 
-$$\int_E \sum_ {n=1}^\infty f_n \,d{\mu} = \sum_ {n=1}^\infty \int_E f_n \,d{\mu}.$$
+$$\int_E \sum _{n=1}^\infty f_n \,d{\mu} = \sum _{n=1}^\infty \int_E f_n \,d{\mu}.$$
 
-**증명.** $\sum_ {n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
+**증명.** $\sum _{n=1}^\infty f_n$는 measurable function의 극한이므로 measurable이다. 무한급수를 부분합의 극한으로 생각하면 $f_n \geq 0$ 이므로 부분합이 증가함을 알 수 있다. 따라서 단조 수렴 정리를 적용하여 결론을 얻는다.
 
 ## Fatou's Lemma
 
@@ -127,15 +127,15 @@ $$\int_E \sum_ {n=1}^\infty f_n \,d{\mu} = \sum_ {n=1}^\infty \int_E f_n \,d{\mu
 
 **정리.** (Fatou) $f_n \geq 0$ 가 measurable이고 $E$가 measurable이라 하자. 다음이 성립한다.
 
-$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf _{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
-**증명.** $g_n = \displaystyle\inf_ {k \geq n} f_k$ 으로 두면 $\displaystyle\lim_ {n \rightarrow\infty} g_n = \liminf_ {n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
+**증명.** $g_n = \displaystyle\inf _{k \geq n} f_k$ 으로 두면 $\displaystyle\lim _{n \rightarrow\infty} g_n = \liminf _{n\rightarrow\infty} f_n$ 이다. $g_n$이 증가함은 쉽게 확인할 수 있으며 $g_n \geq 0$ 이다. $g_n$의 정의로부터 모든 $k \geq n$ 에 대하여 $g_n \leq f_k$ 이므로,
 
-$$\int_E g_n \,d{\mu} \leq \inf_ {k\geq n} \int_E f_k \,d{\mu}$$
+$$\int_E g_n \,d{\mu} \leq \inf _{k\geq n} \int_E f_k \,d{\mu}$$
 
 이다. 여기서 $n \rightarrow\infty$ 로 두면
 
-$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} = \lim_ {n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim_ {n \rightarrow\infty} \inf_ {k \geq n}\int_E f_k \,d{\mu} = \liminf_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} = \lim _{n \rightarrow\infty} \int_E g_n \,d{\mu} \leq \lim _{n \rightarrow\infty} \inf _{k \geq n}\int_E f_k \,d{\mu} = \liminf _{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
 이 된다. 여기서 첫 번째 등호는 단조 수렴 정리에 의해 성립한다.
 
@@ -143,9 +143,9 @@ $$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} = \lim_ {n \rightarrow\infty
 
 **참고.** 왠지 위와 비슷한 결론이 $\limsup$에 대해서도 성립해야 할 것 같습니다. 구체적으로,
 
-$$\int_E \limsup_ {n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_ {n \rightarrow\infty} \int_E f_n \,d{\mu}$$
+$$\int_E \limsup _{n \rightarrow\infty} f_n \,d{\mu} \geq \limsup _{n \rightarrow\infty} \int_E f_n \,d{\mu}$$
 
-일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi_ {[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
+일 것 같습니다. 안타깝게도 이는 성립하지 않습니다. 반례로 앞서 소개한 $\chi _{[n, \infty)}$를 한 번 더 가져올 수 있습니다. 좌변을 계산해 보면 0이지만, 우변을 계산해 보면 $\infty$입니다. 나중에 소개하겠지만, $\lvert f_n \rvert \leq g$ 를 만족하는 함수 $g \in \mathcal{L}^{1}$ 가 존재해야 위 부등식이 성립합니다.
 
 ## Properties of the Lebesgue Integral
 
@@ -191,7 +191,7 @@ $$\int_E \limsup_ {n \rightarrow\infty} f_n \,d{\mu} \geq \limsup_ {n \rightarro
 
 6. 만약 measure가 0인 집합에서 적분을 하면 어떻게 될까요? $\mu(E) = 0$ 라 하고, measurable function $f$를 적분해 보겠습니다. 여기서 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E$ 도 measurable이며 $n \rightarrow\infty$ 일 때 $\min\lbrace \lvert f \rvert, n\rbrace\chi_E \nearrow \lvert f \rvert\chi_E$ 임을 이용합니다. 마지막으로 단조 수렴 정리를 적용하면
 
-	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim_ {n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim_ {n \rightarrow\infty} \int_E n \,d{\mu} = \lim_ {n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
+	$$\begin{aligned}                    \int_E \lvert f \rvert \,d{\mu} &= \lim _{n \rightarrow\infty} \int_E \min\lbrace \lvert f \rvert, n\rbrace \,d{\mu} \\                    &\leq \lim _{n \rightarrow\infty} \int_E n \,d{\mu} = \lim _{n \rightarrow\infty} n\mu(E) = 0                  \end{aligned}$$
 
 	임을 얻습니다. 따라서 $f \in \mathcal{L}^{1}(E, \mu)$ 이고, $\displaystyle\int_E f \,d{\mu} = 0$ 가 되어 적분값이 0임을 알 수 있습니다. 즉, measure가 0인 집합 위에서 적분하면 그 결과는 0이 됩니다.[^1]
 

--- a/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
+++ b/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
@@ -29,7 +29,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 이다.
 
-**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
+**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int _{E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int _{E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
 
 아래 정리는 measure가 0인 집합에서의 적분은 무시해도 됨을 알려줍니다. $u(x) \neq 0$ 인 점들이 존재하더라도, 이 점들의 집합의 measure가 0이면 적분값에 영향을 줄 수 없습니다.
 
@@ -45,7 +45,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 (2 $\iff$ 3) $E\cap\lbrace u\neq 0\rbrace$ 가 measurable이므로 정의에 의해 당연하다.
 
-(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int_ {E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
+(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int _{E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int _{E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
 
 (1 $\implies$ 3) Markov's inequality를 사용하면
 
@@ -67,13 +67,13 @@ $$\int_A f \,d{\mu} = \int_B f \,d{\mu}$$
 
 **증명.** $\mu\left( \lbrace \lvert u \rvert \geq 1\rbrace\cap E \right) \leq \displaystyle\int_E \lvert u \rvert \,d{\mu} < \infty$.[^2] 그러므로
 
-$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap_ {n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim_ {n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup_ {n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
+$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap _{n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim _{n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup _{n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
 
 이다.
 
 적분 가능하다면 어차피 함숫값이 무한한 영역은 적분값에 영향을 주지 않으므로, 함숫값이 유한한 곳에서만 적분해도 될 것입니다.
 
-**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
+**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int _{E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
 
 ### Linearity of the Lebesgue Integral
 
@@ -95,11 +95,11 @@ $$f^+ - f^- = f_1^+ - f_1^- + f_2^+ - f_2^- \implies f^+ + f_1^- + f_2^- = f^- +
 
 이다. 그러면
 
-$$\int_ {E\setminus N} f^+ \,d{\mu} + \int_ {E\setminus N} f_1^- \,d{\mu} + \int_ {E\setminus N} f_2^- \,d{\mu} = \int_ {E\setminus N} f^-\,d{\mu} + \int_ {E\setminus N} f_1^+\,d{\mu} + \int_ {E\setminus N} f_2^+ \,d{\mu}$$
+$$\int _{E\setminus N} f^+ \,d{\mu} + \int _{E\setminus N} f_1^- \,d{\mu} + \int _{E\setminus N} f_2^- \,d{\mu} = \int _{E\setminus N} f^-\,d{\mu} + \int _{E\setminus N} f_1^+\,d{\mu} + \int _{E\setminus N} f_2^+ \,d{\mu}$$
 
 이고, $\mu(N) = 0$ 임을 이용하여 $N$ 위에서의 적분값을 더해주면
 
-$$\int_ {E \setminus N} f \,d{\mu} = \int_ {E \setminus N} f_1 \,d{\mu} + \int_ {E \setminus N} f_2 \,d{\mu} \implies \int_ {E} f \,d{\mu} = \int_ {E} f_1 \,d{\mu} + \int_ {E} f_2 \,d{\mu}$$
+$$\int _{E \setminus N} f \,d{\mu} = \int _{E \setminus N} f_1 \,d{\mu} + \int _{E \setminus N} f_2 \,d{\mu} \implies \int _{E} f \,d{\mu} = \int _{E} f_1 \,d{\mu} + \int _{E} f_2 \,d{\mu}$$
 
 를 얻는다.
 
@@ -107,19 +107,19 @@ $$\int_ {E \setminus N} f \,d{\mu} = \int_ {E \setminus N} f_1 \,d{\mu} + \int_ 
 
 이제 이를 응용하여 수렴정리를 다시 적어보겠습니다. 지난 글에서는 모든 점에서 특정 성질이 성립할 것이 요구되었으나 이제는 거의 모든 점에서만 성립하면 됩니다. 증명은 해당 성질이 성립하지 않는 집합을 빼고 증명하면 됩니다.
 
-**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f_ {n+1}(x)$ $\mu$-a.e. 라 하자.
+**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f _{n+1}(x)$ $\mu$-a.e. 라 하자.
 
-$$\lim_ {n\rightarrow\infty} f_n(x) = f(x)$$
+$$\lim _{n\rightarrow\infty} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\lim_ {n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
+$$\lim _{n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
 
 이다.
 
 **정리.** (Fatou) $f_n$이 measurable이고 $f_n(x) \geq 0$ $\mu$-a.e. 라 하자. 다음이 성립한다.
 
-$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf _{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
 비슷한 느낌으로 다음과 같은 명제를 생각할 수도 있습니다.
 
@@ -149,9 +149,9 @@ $$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace.$$
 
 ![mt-07.png](../../../assets/img/posts/mt-07.png)
 
-**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_ {n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
+**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim _{n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
 
-$$\lim_ {n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
+$$\lim _{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 이다.
 
@@ -165,13 +165,13 @@ $$\lim_ {n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 	이므로 위 정리의 결론은 곧
 
-	$$\lim_ {n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
+	$$\lim _{n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
 
 	를 의미한다.
 
 **증명.** 다음과 같은 집합을 정의한다.
 
-$$A = \left\lbrace \displaystyle x \in E : \lim_ {n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
+$$A = \left\lbrace \displaystyle x \in E : \lim _{n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
 
 그러면 가정에 의해 $\mu\left( E\setminus A \right) = 0$ 이다. 이제 $x \in A$ 에 대해서만 생각해도 충분하다. 그러면
 
@@ -179,13 +179,13 @@ $$2g - \lvert f_n - f \rvert \geq 2g - \bigl(\lvert f_n \rvert + \lvert f \rvert
 
 이다. $\lvert f_n - f \rvert \rightarrow 0$, $2g - \lvert f_n - f \rvert \rightarrow 2g$ 이므로, Fatou’s lemma를 적용하면
 
-$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf_ {n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf_ {n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf _{n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf _{n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
 
 이다. 따라서
 
-$$2 \int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
+$$2 \int_A g \,d{\mu} - \limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
 
-이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
+이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
 
 [^1]: 예를 들어, ‘$f(x)$가 연속이다’ 등.
 

--- a/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
+++ b/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
@@ -29,7 +29,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 이다.
 
-**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
+**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
 
 아래 정리는 measure가 0인 집합에서의 적분은 무시해도 됨을 알려줍니다. $u(x) \neq 0$ 인 점들이 존재하더라도, 이 점들의 집합의 measure가 0이면 적분값에 영향을 줄 수 없습니다.
 
@@ -45,7 +45,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 (2 $\iff$ 3) $E\cap\lbrace u\neq 0\rbrace$ 가 measurable이므로 정의에 의해 당연하다.
 
-(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int_{E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
+(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int_ {E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
 
 (1 $\implies$ 3) Markov's inequality를 사용하면
 
@@ -67,13 +67,13 @@ $$\int_A f \,d{\mu} = \int_B f \,d{\mu}$$
 
 **증명.** $\mu\left( \lbrace \lvert u \rvert \geq 1\rbrace\cap E \right) \leq \displaystyle\int_E \lvert u \rvert \,d{\mu} < \infty$.[^2] 그러므로
 
-$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap_{n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim_{n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup_{n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
+$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap_ {n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim_ {n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup_ {n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
 
 이다.
 
 적분 가능하다면 어차피 함숫값이 무한한 영역은 적분값에 영향을 주지 않으므로, 함숫값이 유한한 곳에서만 적분해도 될 것입니다.
 
-**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
+**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
 
 ### Linearity of the Lebesgue Integral
 
@@ -95,11 +95,11 @@ $$f^+ - f^- = f_1^+ - f_1^- + f_2^+ - f_2^- \implies f^+ + f_1^- + f_2^- = f^- +
 
 이다. 그러면
 
-$$\int_{E\setminus N} f^+ \,d{\mu} + \int_{E\setminus N} f_1^- \,d{\mu} + \int_{E\setminus N} f_2^- \,d{\mu} = \int_{E\setminus N} f^-\,d{\mu} + \int_{E\setminus N} f_1^+\,d{\mu} + \int_{E\setminus N} f_2^+ \,d{\mu}$$
+$$\int_ {E\setminus N} f^+ \,d{\mu} + \int_ {E\setminus N} f_1^- \,d{\mu} + \int_ {E\setminus N} f_2^- \,d{\mu} = \int_ {E\setminus N} f^-\,d{\mu} + \int_ {E\setminus N} f_1^+\,d{\mu} + \int_ {E\setminus N} f_2^+ \,d{\mu}$$
 
 이고, $\mu(N) = 0$ 임을 이용하여 $N$ 위에서의 적분값을 더해주면
 
-$$\int_{E \setminus N} f \,d{\mu} = \int_{E \setminus N} f_1 \,d{\mu} + \int_{E \setminus N} f_2 \,d{\mu} \implies \int_{E} f \,d{\mu} = \int_{E} f_1 \,d{\mu} + \int_{E} f_2 \,d{\mu}$$
+$$\int_ {E \setminus N} f \,d{\mu} = \int_ {E \setminus N} f_1 \,d{\mu} + \int_ {E \setminus N} f_2 \,d{\mu} \implies \int_ {E} f \,d{\mu} = \int_ {E} f_1 \,d{\mu} + \int_ {E} f_2 \,d{\mu}$$
 
 를 얻는다.
 
@@ -107,19 +107,19 @@ $$\int_{E \setminus N} f \,d{\mu} = \int_{E \setminus N} f_1 \,d{\mu} + \int_{E 
 
 이제 이를 응용하여 수렴정리를 다시 적어보겠습니다. 지난 글에서는 모든 점에서 특정 성질이 성립할 것이 요구되었으나 이제는 거의 모든 점에서만 성립하면 됩니다. 증명은 해당 성질이 성립하지 않는 집합을 빼고 증명하면 됩니다.
 
-**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f_{n+1}(x)$ $\mu$-a.e. 라 하자.
+**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f_ {n+1}(x)$ $\mu$-a.e. 라 하자.
 
-$$\lim_{n\rightarrow\infty} f_n(x) = f(x)$$
+$$\lim_ {n\rightarrow\infty} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\lim_{n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
+$$\lim_ {n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
 
 이다.
 
 **정리.** (Fatou) $f_n$이 measurable이고 $f_n(x) \geq 0$ $\mu$-a.e. 라 하자. 다음이 성립한다.
 
-$$\int_E \liminf_{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
 비슷한 느낌으로 다음과 같은 명제를 생각할 수도 있습니다.
 
@@ -149,9 +149,9 @@ $$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace.$$
 
 ![mt-07.png](../../../assets/img/posts/mt-07.png)
 
-**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_{n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
+**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_ {n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
 
-$$\lim_{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
+$$\lim_ {n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 이다.
 
@@ -165,13 +165,13 @@ $$\lim_{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 	이므로 위 정리의 결론은 곧
 
-	$$\lim_{n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
+	$$\lim_ {n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
 
 	를 의미한다.
 
 **증명.** 다음과 같은 집합을 정의한다.
 
-$$A = \left\lbrace \displaystyle x \in E : \lim_{n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
+$$A = \left\lbrace \displaystyle x \in E : \lim_ {n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
 
 그러면 가정에 의해 $\mu\left( E\setminus A \right) = 0$ 이다. 이제 $x \in A$ 에 대해서만 생각해도 충분하다. 그러면
 
@@ -179,13 +179,13 @@ $$2g - \lvert f_n - f \rvert \geq 2g - \bigl(\lvert f_n \rvert + \lvert f \rvert
 
 이다. $\lvert f_n - f \rvert \rightarrow 0$, $2g - \lvert f_n - f \rvert \rightarrow 2g$ 이므로, Fatou’s lemma를 적용하면
 
-$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf_{n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf_{n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup_{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf_ {n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf_ {n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
 
 이다. 따라서
 
-$$2 \int_A g \,d{\mu} - \limsup_{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
+$$2 \int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
 
-이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup_{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
+이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
 
 [^1]: 예를 들어, ‘$f(x)$가 연속이다’ 등.
 

--- a/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
+++ b/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
@@ -29,7 +29,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 이다.
 
-**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int _{E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int _{E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
+**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int_ {E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
 
 아래 정리는 measure가 0인 집합에서의 적분은 무시해도 됨을 알려줍니다. $u(x) \neq 0$ 인 점들이 존재하더라도, 이 점들의 집합의 measure가 0이면 적분값에 영향을 줄 수 없습니다.
 
@@ -45,7 +45,7 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c
 
 (2 $\iff$ 3) $E\cap\lbrace u\neq 0\rbrace$ 가 measurable이므로 정의에 의해 당연하다.
 
-(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int _{E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int _{E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
+(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int_ {E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
 
 (1 $\implies$ 3) Markov's inequality를 사용하면
 
@@ -67,13 +67,13 @@ $$\int_A f \,d{\mu} = \int_B f \,d{\mu}$$
 
 **증명.** $\mu\left( \lbrace \lvert u \rvert \geq 1\rbrace\cap E \right) \leq \displaystyle\int_E \lvert u \rvert \,d{\mu} < \infty$.[^2] 그러므로
 
-$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap _{n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim _{n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup _{n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
+$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap_ {n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim_ {n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup_ {n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
 
 이다.
 
 적분 가능하다면 어차피 함숫값이 무한한 영역은 적분값에 영향을 주지 않으므로, 함숫값이 유한한 곳에서만 적분해도 될 것입니다.
 
-**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int _{E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
+**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_ {E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
 
 ### Linearity of the Lebesgue Integral
 
@@ -95,11 +95,11 @@ $$f^+ - f^- = f_1^+ - f_1^- + f_2^+ - f_2^- \implies f^+ + f_1^- + f_2^- = f^- +
 
 이다. 그러면
 
-$$\int _{E\setminus N} f^+ \,d{\mu} + \int _{E\setminus N} f_1^- \,d{\mu} + \int _{E\setminus N} f_2^- \,d{\mu} = \int _{E\setminus N} f^-\,d{\mu} + \int _{E\setminus N} f_1^+\,d{\mu} + \int _{E\setminus N} f_2^+ \,d{\mu}$$
+$$\int_ {E\setminus N} f^+ \,d{\mu} + \int_ {E\setminus N} f_1^- \,d{\mu} + \int_ {E\setminus N} f_2^- \,d{\mu} = \int_ {E\setminus N} f^-\,d{\mu} + \int_ {E\setminus N} f_1^+\,d{\mu} + \int_ {E\setminus N} f_2^+ \,d{\mu}$$
 
 이고, $\mu(N) = 0$ 임을 이용하여 $N$ 위에서의 적분값을 더해주면
 
-$$\int _{E \setminus N} f \,d{\mu} = \int _{E \setminus N} f_1 \,d{\mu} + \int _{E \setminus N} f_2 \,d{\mu} \implies \int _{E} f \,d{\mu} = \int _{E} f_1 \,d{\mu} + \int _{E} f_2 \,d{\mu}$$
+$$\int_ {E \setminus N} f \,d{\mu} = \int_ {E \setminus N} f_1 \,d{\mu} + \int_ {E \setminus N} f_2 \,d{\mu} \implies \int_ {E} f \,d{\mu} = \int_ {E} f_1 \,d{\mu} + \int_ {E} f_2 \,d{\mu}$$
 
 를 얻는다.
 
@@ -107,19 +107,19 @@ $$\int _{E \setminus N} f \,d{\mu} = \int _{E \setminus N} f_1 \,d{\mu} + \int _
 
 이제 이를 응용하여 수렴정리를 다시 적어보겠습니다. 지난 글에서는 모든 점에서 특정 성질이 성립할 것이 요구되었으나 이제는 거의 모든 점에서만 성립하면 됩니다. 증명은 해당 성질이 성립하지 않는 집합을 빼고 증명하면 됩니다.
 
-**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f _{n+1}(x)$ $\mu$-a.e. 라 하자.
+**정리.** (단조 수렴 정리) $f_n$이 measurable이고 $0 \leq f_n(x) \leq f_ {n+1}(x)$ $\mu$-a.e. 라 하자.
 
-$$\lim _{n\rightarrow\infty} f_n(x) = f(x)$$
+$$\lim_ {n\rightarrow\infty} f_n(x) = f(x)$$
 
 로 두면,
 
-$$\lim _{n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
+$$\lim_ {n \rightarrow\infty} \int_E f_n \,d{\mu} = \int_E f \,d{\mu}.$$
 
 이다.
 
 **정리.** (Fatou) $f_n$이 measurable이고 $f_n(x) \geq 0$ $\mu$-a.e. 라 하자. 다음이 성립한다.
 
-$$\int_E \liminf _{n\rightarrow\infty} f_n \,d{\mu} \leq \liminf _{n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
+$$\int_E \liminf_ {n\rightarrow\infty} f_n \,d{\mu} \leq \liminf_ {n\rightarrow\infty} \int_E f_n \,d{\mu}.$$
 
 비슷한 느낌으로 다음과 같은 명제를 생각할 수도 있습니다.
 
@@ -149,9 +149,9 @@ $$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace.$$
 
 ![mt-07.png](../../../assets/img/posts/mt-07.png)
 
-**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim _{n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
+**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_ {n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
 
-$$\lim _{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
+$$\lim_ {n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 이다.
 
@@ -165,13 +165,13 @@ $$\lim _{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 	이므로 위 정리의 결론은 곧
 
-	$$\lim _{n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
+	$$\lim_ {n \rightarrow\infty} \int f_n \,d{\mu} = \int f \,d{\mu}$$
 
 	를 의미한다.
 
 **증명.** 다음과 같은 집합을 정의한다.
 
-$$A = \left\lbrace \displaystyle x \in E : \lim _{n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
+$$A = \left\lbrace \displaystyle x \in E : \lim_ {n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
 
 그러면 가정에 의해 $\mu\left( E\setminus A \right) = 0$ 이다. 이제 $x \in A$ 에 대해서만 생각해도 충분하다. 그러면
 
@@ -179,13 +179,13 @@ $$2g - \lvert f_n - f \rvert \geq 2g - \bigl(\lvert f_n \rvert + \lvert f \rvert
 
 이다. $\lvert f_n - f \rvert \rightarrow 0$, $2g - \lvert f_n - f \rvert \rightarrow 2g$ 이므로, Fatou’s lemma를 적용하면
 
-$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf _{n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf _{n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
+$$\begin{aligned}        2 \int_E g \,d{\mu} = \int_A 2g \,d{\mu} & = \int_A \liminf_ {n \rightarrow\infty} \big(2g - \lvert f_n - f \rvert\big) \,d{\mu} \\                                               & \leq \liminf_ {n \rightarrow\infty} \left( 2 \int_A g \,d{\mu} - \int_A \lvert f_n - f \rvert \,d{\mu} \right) \\                                               & = 2\int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} \leq 2 \int_A g \,d{\mu}    \end{aligned}$$
 
 이다. 따라서
 
-$$2 \int_A g \,d{\mu} - \limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
+$$2 \int_A g \,d{\mu} - \limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 2 \int_A g \,d{\mu}$$
 
-이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup _{n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
+이고, 가정에 의해 $\displaystyle 0 \leq \int_A g \,d{\mu} < \infty$ 이므로 $\displaystyle\limsup_ {n \rightarrow\infty} \int_A \lvert f_n - f \rvert \,d{\mu} = 0$ 이다.
 
 [^1]: 예를 들어, ‘$f(x)$가 연속이다’ 등.
 

--- a/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
+++ b/_posts/Mathematics/Measure Theory/2023-04-07-dominated-convergence-theorem.md
@@ -25,11 +25,11 @@ image:
 
 **정리.** (Markov's Inequality) $u \in \mathcal{L}^{1}(E, \mu)$ 라 하자. 모든 $c > 0$ 에 대하여
 
-$$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace  \cap E \right) \leq \frac{1}{c} \int_E \lvert u \rvert \,d{\mu}$$
+$$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right) \leq \frac{1}{c} \int_E \lvert u \rvert \,d{\mu}$$
 
 이다.
 
-**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace } \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace } c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace  \cap E \right)$.
+**증명.** $\displaystyle\int_E \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace} \lvert u \rvert \,d{\mu} \geq \int_{E\cap \lbrace \lvert u \rvert\geq c\rbrace} c \,d{\mu} = c \mu\left( \lbrace \lvert u \rvert \geq c\rbrace \cap E \right)$.
 
 아래 정리는 measure가 0인 집합에서의 적분은 무시해도 됨을 알려줍니다. $u(x) \neq 0$ 인 점들이 존재하더라도, 이 점들의 집합의 measure가 0이면 적분값에 영향을 줄 수 없습니다.
 
@@ -39,19 +39,19 @@ $$\mu\left( \lbrace \lvert u \rvert \geq c\rbrace  \cap E \right) \leq \frac{1}{
 
 2. $u = 0$ $\mu$-a.e. on $E$.
 
-3. $\mu\left( \lbrace x \in E : u(x) \neq 0\rbrace  \right) = 0$.
+3. $\mu\left( \lbrace x \in E : u(x) \neq 0\rbrace \right) = 0$.
 
 **증명.**
 
-(2 $\iff$ 3) $E\cap\lbrace u\neq 0\rbrace $ 가 measurable이므로 정의에 의해 당연하다.
+(2 $\iff$ 3) $E\cap\lbrace u\neq 0\rbrace$ 가 measurable이므로 정의에 의해 당연하다.
 
-(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert > 0\rbrace } \lvert u \rvert \,d{\mu} + \int_{E \cap \lbrace \lvert u \rvert = 0\rbrace } \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
+(2 $\implies$ 1) $\displaystyle\int_E \lvert u \rvert \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert > 0\rbrace} \lvert u \rvert \,d{\mu} + \int_{E \cap \lbrace \lvert u \rvert = 0\rbrace} \lvert u \rvert \,d{\mu} = 0 + 0 = 0$.
 
 (1 $\implies$ 3) Markov's inequality를 사용하면
 
-$$\mu\left( \left\lbrace \lvert u \rvert \geq \frac{1}{n}\right\rbrace  \cap E \right) \leq n\int_E \lvert u \rvert \,d{\mu} = 0$$
+$$\mu\left( \left\lbrace \lvert u \rvert \geq \frac{1}{n}\right\rbrace \cap E \right) \leq n\int_E \lvert u \rvert \,d{\mu} = 0$$
 
-이다. 이제 $n\rightarrow\infty$ 일 때 continuity of measure를 사용하면 $\mu\left( \lbrace \lvert u \rvert > 0\rbrace  \cap E \right) = 0$ 이다.
+이다. 이제 $n\rightarrow\infty$ 일 때 continuity of measure를 사용하면 $\mu\left( \lbrace \lvert u \rvert > 0\rbrace \cap E \right) = 0$ 이다.
 
 위 정리의 결과를 생각해 보면 다음이 성립함도 알 수 있습니다.
 
@@ -65,15 +65,15 @@ $$\int_A f \,d{\mu} = \int_B f \,d{\mu}$$
 
 **정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $u(x) \in \mathbb{R}$ $\mu$-a.e. on $E$ 이다. 즉, $u(x) = \infty$ 인 집합의 measure가 0이다.
 
-**증명.** $\mu\left( \lbrace \lvert u \rvert \geq 1\rbrace \cap E \right) \leq \displaystyle\int_E \lvert u \rvert \,d{\mu} < \infty$.[^2] 그러므로
+**증명.** $\mu\left( \lbrace \lvert u \rvert \geq 1\rbrace\cap E \right) \leq \displaystyle\int_E \lvert u \rvert \,d{\mu} < \infty$.[^2] 그러므로
 
-$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace  \cap E \right) & = \mu\left( \bigcap_{n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace  \right) \\                                               & = \lim_{n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace  \cap E \right) \leq \limsup_{n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
+$$\begin{aligned}        \mu\left( \lbrace \lvert u \rvert = \infty\rbrace \cap E \right) & = \mu\left( \bigcap_{n=1}^\infty \lbrace x \in E : \lvert u(x) \rvert \geq n\rbrace \right) \\                                               & = \lim_{n \rightarrow\infty} \mu\left( \lbrace \lvert u \rvert \geq n\rbrace \cap E \right) \leq \limsup_{n\rightarrow\infty} \frac{1}{n} \int_E \lvert u \rvert \,d{\mu} = 0    \end{aligned}$$
 
 이다.
 
 적분 가능하다면 어차피 함숫값이 무한한 영역은 적분값에 영향을 주지 않으므로, 함숫값이 유한한 곳에서만 적분해도 될 것입니다.
 
-**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert < \infty\rbrace } u \,d{\mu}$ 이다.
+**따름정리.** $u \in \mathcal{L}^{1}(E, \mu)$ 이면 $\displaystyle\int_E u \,d{\mu} = \int_{E \cap \lbrace \lvert u \rvert < \infty\rbrace} u \,d{\mu}$ 이다.
 
 ### Linearity of the Lebesgue Integral
 
@@ -87,7 +87,7 @@ $$\int_E \left( f_1 + f_2 \right) \,d{\mu} = \int_E f_1 \,d{\mu} + \int_E f_2 \,
 
 **증명.** $\lvert f_1 + f_2 \rvert \leq \lvert f_1 \rvert + \lvert f_2 \rvert$ 임을 이용하면 $f_1+f_2 \in \mathcal{L}^{1}(E, \mu)$ 인 것은 당연하다. 이제 $f = f_1 + f_2$ 로 두고
 
-$$N = \left\lbrace x : \max\left\lbrace f_1^+, f_1^-, f_2^+, f_2^-, f^+, f^-\right\rbrace  = \infty \right\rbrace$$
+$$N = \left\lbrace x : \max\left\lbrace f_1^+, f_1^-, f_2^+, f_2^-, f^+, f^-\right\rbrace = \infty \right\rbrace$$
 
 으로 정의하자. 함수들이 모두 적분 가능하므로 위 정리에 의해 $\mu(N) = 0$ 이다. 그러므로 $E \setminus N$ 에서는 무한한 값이 없으므로 이항을 편하게 할 수 있다. 즉,
 
@@ -139,7 +139,7 @@ $$\int \lvert f \rvert \,d{\mu} \leq \int \lvert g \rvert \,d{\mu}$$
 
 그러면 $\sim$은 equivalence relation이고 다음과 같이 적을 수 있다.
 
-$$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace .$$
+$$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace.$$
 
 이처럼 equivalence relation을 정의하면 equivalence class의 대표에 대해서만 생각해도 충분합니다. 사실상 거의 모든 점에서 함숫값이 같다면 같은 함수로 보겠다는 뜻이 됩니다.
 
@@ -149,7 +149,7 @@ $$[f] = \lbrace g \in \mathcal{L}^{1}(E, \mu) : f \sim g\rbrace .$$
 
 ![mt-07.png](../../../assets/img/posts/mt-07.png)
 
-**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace $이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_{n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
+**정리.** (지배 수렴 정리) Measurable set $E$와 measurable function $f$에 대하여, $\lbrace f_n\rbrace$이 measurable function의 함수열이라 하자. $E$의 거의 모든 점 위에서 극한 $f(x) = \displaystyle\lim_{n \rightarrow\infty} f_n(x)$ 가 $\overline{\mathbb{R}}$에 존재하고 (점별 수렴) $\lvert f_n \rvert \leq g \quad \mu$-a.e. on $E$ ($\forall n \geq 1$) 를 만족하는 $g \in \mathcal{L}^{1}(E, \mu)$ 가 존재하면,
 
 $$\lim_{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
@@ -171,7 +171,7 @@ $$\lim_{n \rightarrow\infty} \int_E \lvert f_n - f \rvert \,d{\mu} = 0$$
 
 **증명.** 다음과 같은 집합을 정의한다.
 
-$$A = \left\lbrace \displaystyle x \in E : \lim_{n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace .$$
+$$A = \left\lbrace \displaystyle x \in E : \lim_{n \rightarrow\infty} f_n(x) \text{가 존재하고}, f_n(x), f(x), g(x) \in \mathbb{R}, \lvert f_n(x) \rvert \leq g(x)\right\rbrace.$$
 
 그러면 가정에 의해 $\mu\left( E\setminus A \right) = 0$ 이다. 이제 $x \in A$ 에 대해서만 생각해도 충분하다. 그러면
 
@@ -190,4 +190,3 @@ $$2 \int_A g \,d{\mu} - \limsup_{n \rightarrow\infty} \int_A \lvert f_n - f \rve
 [^1]: 예를 들어, ‘$f(x)$가 연속이다’ 등.
 
 [^2]: Continuity of measure를 사용하기 위해서는 첫 번째 집합의 measure가 유한해야 한다.
-

--- a/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
+++ b/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
@@ -35,7 +35,7 @@ $$\mathcal{R}\int_a^b f\,d{x}$$
 
 또한 (2)는 리만 적분 가능성에 대한 동치 조건을 알려줍니다. Almost everywhere라는 조건이 붙었기 때문에, $\mathcal{L}^1$의 equivalence class를 고려하면 사실상 연속함수에 대해서만 리만 적분이 가능하다는 뜻이 됩니다.
 
-**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_{n_k}^k = b\rbrace $ 를 잡는다. 단 $P_k \subseteq P_{k+1}$ (refinement) 이고 $\lvert x_{i}^k - x_{i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
+**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_{n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P_{k+1}$ (refinement) 이고 $\lvert x_{i}^k - x_{i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
 
 그러면 리만 적분의 정의로부터
 
@@ -89,11 +89,11 @@ $$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M_{j_0}^n - m_{j_0}^n 
 
 가 됨을 알 수 있다.
 
-위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace  \setminus\bigcup_{k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
+위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_{k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
 
 따라서, $f$가 연속인 점들의 집합을 $C_f$라 하면
 
-$$\lbrace x : U(x) = L(x)\rbrace  \setminus\bigcup_{k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
+$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_{k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
 
 이 된다. 한편 $\bigcup_{k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
 
@@ -126,4 +126,3 @@ $$\lbrace x : U(x) = L(x)\rbrace  \setminus\bigcup_{k=1}^{\infty} P_k \subseteq 
 $$\int_0^1 f\,d{x} = \lim_{n \rightarrow\infty} \int_{0}^1 f_n \,d{x} = \lim_{n \rightarrow\infty}\int_{1/n}^1 f \,d{x} = \lim_{n \rightarrow\infty} \mathcal{R}\int_{1/n}^1 f \,d{x}$$
 
 이 된다.
-

--- a/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
+++ b/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
@@ -17,7 +17,7 @@ image:
 
 먼저 혼동을 막기 위해 Lebesgue measure $m$에 대하여 르벡 적분을
 
-$$\int_{[a, b]} f \,d{m} = \int_{[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
+$$\int_ {[a, b]} f \,d{m} = \int_ {[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
 
 와 같이 표기하고, 리만 적분은
 
@@ -35,39 +35,39 @@ $$\mathcal{R}\int_a^b f\,d{x}$$
 
 또한 (2)는 리만 적분 가능성에 대한 동치 조건을 알려줍니다. Almost everywhere라는 조건이 붙었기 때문에, $\mathcal{L}^1$의 equivalence class를 고려하면 사실상 연속함수에 대해서만 리만 적분이 가능하다는 뜻이 됩니다.
 
-**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_{n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P_{k+1}$ (refinement) 이고 $\lvert x_{i}^k - x_{i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
+**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_ {n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P_ {k+1}$ (refinement) 이고 $\lvert x_ {i}^k - x_ {i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
 
 그러면 리만 적분의 정의로부터
 
-$$\lim_{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_{a}^{b}} f\,d{x}, \quad \lim_{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_{a}^{b}} f \,d{x}$$
+$$\lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x}, \quad \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x}$$
 
 임을 알 수 있다.
 
 이제 measurable simple function $U_k, L_k$를 다음과 같이 잡는다.
 
-$$U_k = \sum_{i=1}^{n_k} \sup_{x_{i-1}^k \leq y \leq x_{i}^k} f(y) \chi_{(x_{i-1}^k, x_i^k]}, \quad L_k = \sum_{i=1}^{n_k} \inf_{x_{i-1}^k \leq y \leq x_{i}^k} f(y) \chi_{(x_{i-1}^k, x_i^k]}.$$
+$$U_k = \sum_ {i=1}^{n_k} \sup_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}, \quad L_k = \sum_ {i=1}^{n_k} \inf_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}.$$
 
 그러면 구간 $[a, b]$ 위에서 $L_k \leq f \leq U_k$인 것은 당연하고, 르벡 적분이 가능하므로
 
 $$\int_a^b L_k \,d{x} = L(P_k, f), \quad \int_a^b U_k \,d{x} = U(P_k, f)$$
 
-이 됨을 알 수 있다. 여기서 $P_k \subseteq P_{k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
+이 됨을 알 수 있다. 여기서 $P_k \subseteq P_ {k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
 
 그러므로
 
-$$L(x) = \lim_{k \rightarrow\infty} L_k(x), \quad U(x) = \lim_{k \rightarrow\infty} U_k(x)$$
+$$L(x) = \lim_ {k \rightarrow\infty} L_k(x), \quad U(x) = \lim_ {k \rightarrow\infty} U_k(x)$$
 
 로 정의했을 때, 극한이 존재함을 알 수 있다. 여기서 $f, L_k, U_k$가 모두 유계인 함수이므로 지배 수렴 정리에 의해
 
-$$\int_a^b L \,d{x} = \lim_{k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim_{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_{a}^{b}} f\,d{x} < \infty,$$
+$$\int_a^b L \,d{x} = \lim_ {k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} < \infty,$$
 
-$$\int_a^b U\,d{x} = \lim_{k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim_{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_{a}^{b}} f \,d{x} < \infty$$
+$$\int_a^b U\,d{x} = \lim_ {k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x} < \infty$$
 
 이므로 $L, U \in \mathcal{L}^{1}[a, b]$ 이다.
 
 위 사실을 종합하면 $f \in \mathcal{R}[a, b]$ 일 때,
 
-$$\mathcal{R}\underline{\int_{a}^{b}} f\,d{x} = \mathcal{R}\overline{\int_{a}^{b}} f\,d{x}$$
+$$\mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} = \mathcal{R}\overline{\int_ {a}^{b}} f\,d{x}$$
 
 이므로
 
@@ -79,29 +79,29 @@ $$\int_a^b (U - L)\,d{x} = 0$$
 
 $$\int_a^b f \,d{x} = \mathcal{R}\int_a^b f\,d{x} < \infty \implies f \in \mathcal{L}^{1}[a, b].$$
 
-(2) 만약 $x \notin \bigcup_{k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t_{j_0-1}^n, t_{j_0}^n)$ 이면서
+(2) 만약 $x \notin \bigcup_ {k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 이면서
 
 $$\lvert L_n(x) - L(x) \rvert + \lvert U_n(x) - U(x) \rvert < \epsilon$$
 
-이 되도록 할 수 있다. 그러면 $y \in (t_{j_0-1}^n, t_{j_0}^n)$ 일 때
+이 되도록 할 수 있다. 그러면 $y \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 일 때
 
-$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M_{j_0}^n - m_{j_0}^n = M_{j_0}^n - U(x) + U(x) - L(x) + L(x) - m_{j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
+$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M_ {j_0}^n - m_ {j_0}^n = M_ {j_0}^n - U(x) + U(x) - L(x) + L(x) - m_ {j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
 
 가 됨을 알 수 있다.
 
-위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_{k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
+위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
 
 따라서, $f$가 연속인 점들의 집합을 $C_f$라 하면
 
-$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_{k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
+$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
 
-이 된다. 한편 $\bigcup_{k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
+이 된다. 한편 $\bigcup_ {k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
 
 아래는 증명의 부산물입니다.
 
 **참고.**
 
-1. $x \notin \bigcup_{k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
+1. $x \notin \bigcup_ {k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
 
 2. $L(x) \leq f(x) \leq U(x)$ 이고 measurable function의 극한인 $L(x), U(x)$ 또한 measurable이다.
 
@@ -109,20 +109,20 @@ $$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_{k=1}^{\infty} P_k \subseteq C
 
 이제 리만 적분의 유용한 성질들을 가지고 와서 사용할 수 있습니다.
 
-1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi_{[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
+1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi_ {[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
 
-	$$\int_0^\infty f \,d{x} = \lim_{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_{n \rightarrow\infty} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x}$$
 
 	이다. 마지막 적분을 리만 적분으로 계산할 수 있다.
 
-2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi_{[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
+2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi_ {[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
 
-	$$\int_0^\infty f \,d{x} = \lim_{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_{n \rightarrow\infty} \int_0^n f \,d{x} = \lim_{n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
 
 	임을 알 수 있다.
 
-마찬가지로 $f_n = f\chi_{(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
+마찬가지로 $f_n = f\chi_ {(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
 
-$$\int_0^1 f\,d{x} = \lim_{n \rightarrow\infty} \int_{0}^1 f_n \,d{x} = \lim_{n \rightarrow\infty}\int_{1/n}^1 f \,d{x} = \lim_{n \rightarrow\infty} \mathcal{R}\int_{1/n}^1 f \,d{x}$$
+$$\int_0^1 f\,d{x} = \lim_ {n \rightarrow\infty} \int_ {0}^1 f_n \,d{x} = \lim_ {n \rightarrow\infty}\int_ {1/n}^1 f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R}\int_ {1/n}^1 f \,d{x}$$
 
 이 된다.

--- a/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
+++ b/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
@@ -17,7 +17,7 @@ image:
 
 먼저 혼동을 막기 위해 Lebesgue measure $m$에 대하여 르벡 적분을
 
-$$\int_ {[a, b]} f \,d{m} = \int_ {[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
+$$\int _{[a, b]} f \,d{m} = \int _{[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
 
 와 같이 표기하고, 리만 적분은
 
@@ -35,39 +35,39 @@ $$\mathcal{R}\int_a^b f\,d{x}$$
 
 또한 (2)는 리만 적분 가능성에 대한 동치 조건을 알려줍니다. Almost everywhere라는 조건이 붙었기 때문에, $\mathcal{L}^1$의 equivalence class를 고려하면 사실상 연속함수에 대해서만 리만 적분이 가능하다는 뜻이 됩니다.
 
-**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_ {n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P_ {k+1}$ (refinement) 이고 $\lvert x_ {i}^k - x_ {i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
+**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x _{n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P _{k+1}$ (refinement) 이고 $\lvert x _{i}^k - x _{i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
 
 그러면 리만 적분의 정의로부터
 
-$$\lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x}, \quad \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x}$$
+$$\lim _{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int _{a}^{b}} f\,d{x}, \quad \lim _{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int _{a}^{b}} f \,d{x}$$
 
 임을 알 수 있다.
 
 이제 measurable simple function $U_k, L_k$를 다음과 같이 잡는다.
 
-$$U_k = \sum_ {i=1}^{n_k} \sup_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}, \quad L_k = \sum_ {i=1}^{n_k} \inf_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}.$$
+$$U_k = \sum _{i=1}^{n_k} \sup _{x _{i-1}^k \leq y \leq x _{i}^k} f(y) \chi _{(x _{i-1}^k, x_i^k]}, \quad L_k = \sum _{i=1}^{n_k} \inf _{x _{i-1}^k \leq y \leq x _{i}^k} f(y) \chi _{(x _{i-1}^k, x_i^k]}.$$
 
 그러면 구간 $[a, b]$ 위에서 $L_k \leq f \leq U_k$인 것은 당연하고, 르벡 적분이 가능하므로
 
 $$\int_a^b L_k \,d{x} = L(P_k, f), \quad \int_a^b U_k \,d{x} = U(P_k, f)$$
 
-이 됨을 알 수 있다. 여기서 $P_k \subseteq P_ {k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
+이 됨을 알 수 있다. 여기서 $P_k \subseteq P _{k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
 
 그러므로
 
-$$L(x) = \lim_ {k \rightarrow\infty} L_k(x), \quad U(x) = \lim_ {k \rightarrow\infty} U_k(x)$$
+$$L(x) = \lim _{k \rightarrow\infty} L_k(x), \quad U(x) = \lim _{k \rightarrow\infty} U_k(x)$$
 
 로 정의했을 때, 극한이 존재함을 알 수 있다. 여기서 $f, L_k, U_k$가 모두 유계인 함수이므로 지배 수렴 정리에 의해
 
-$$\int_a^b L \,d{x} = \lim_ {k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} < \infty,$$
+$$\int_a^b L \,d{x} = \lim _{k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim _{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int _{a}^{b}} f\,d{x} < \infty,$$
 
-$$\int_a^b U\,d{x} = \lim_ {k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x} < \infty$$
+$$\int_a^b U\,d{x} = \lim _{k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim _{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int _{a}^{b}} f \,d{x} < \infty$$
 
 이므로 $L, U \in \mathcal{L}^{1}[a, b]$ 이다.
 
 위 사실을 종합하면 $f \in \mathcal{R}[a, b]$ 일 때,
 
-$$\mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} = \mathcal{R}\overline{\int_ {a}^{b}} f\,d{x}$$
+$$\mathcal{R}\underline{\int _{a}^{b}} f\,d{x} = \mathcal{R}\overline{\int _{a}^{b}} f\,d{x}$$
 
 이므로
 
@@ -79,29 +79,29 @@ $$\int_a^b (U - L)\,d{x} = 0$$
 
 $$\int_a^b f \,d{x} = \mathcal{R}\int_a^b f\,d{x} < \infty \implies f \in \mathcal{L}^{1}[a, b].$$
 
-(2) 만약 $x \notin \bigcup_ {k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 이면서
+(2) 만약 $x \notin \bigcup _{k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t _{j_0-1}^n, t _{j_0}^n)$ 이면서
 
 $$\lvert L_n(x) - L(x) \rvert + \lvert U_n(x) - U(x) \rvert < \epsilon$$
 
-이 되도록 할 수 있다. 그러면 $y \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 일 때
+이 되도록 할 수 있다. 그러면 $y \in (t _{j_0-1}^n, t _{j_0}^n)$ 일 때
 
-$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M_ {j_0}^n - m_ {j_0}^n = M_ {j_0}^n - U(x) + U(x) - L(x) + L(x) - m_ {j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
+$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M _{j_0}^n - m _{j_0}^n = M _{j_0}^n - U(x) + U(x) - L(x) + L(x) - m _{j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
 
 가 됨을 알 수 있다.
 
-위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
+위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup _{k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
 
 따라서, $f$가 연속인 점들의 집합을 $C_f$라 하면
 
-$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
+$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup _{k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
 
-이 된다. 한편 $\bigcup_ {k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
+이 된다. 한편 $\bigcup _{k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
 
 아래는 증명의 부산물입니다.
 
 **참고.**
 
-1. $x \notin \bigcup_ {k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
+1. $x \notin \bigcup _{k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
 
 2. $L(x) \leq f(x) \leq U(x)$ 이고 measurable function의 극한인 $L(x), U(x)$ 또한 measurable이다.
 
@@ -109,20 +109,20 @@ $$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k \subseteq 
 
 이제 리만 적분의 유용한 성질들을 가지고 와서 사용할 수 있습니다.
 
-1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi_ {[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
+1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi _{[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
 
-	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim _{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim _{n \rightarrow\infty} \int_0^n f \,d{x}$$
 
 	이다. 마지막 적분을 리만 적분으로 계산할 수 있다.
 
-2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi_ {[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
+2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi _{[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
 
-	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim _{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim _{n \rightarrow\infty} \int_0^n f \,d{x} = \lim _{n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
 
 	임을 알 수 있다.
 
-마찬가지로 $f_n = f\chi_ {(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
+마찬가지로 $f_n = f\chi _{(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
 
-$$\int_0^1 f\,d{x} = \lim_ {n \rightarrow\infty} \int_ {0}^1 f_n \,d{x} = \lim_ {n \rightarrow\infty}\int_ {1/n}^1 f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R}\int_ {1/n}^1 f \,d{x}$$
+$$\int_0^1 f\,d{x} = \lim _{n \rightarrow\infty} \int _{0}^1 f_n \,d{x} = \lim _{n \rightarrow\infty}\int _{1/n}^1 f \,d{x} = \lim _{n \rightarrow\infty} \mathcal{R}\int _{1/n}^1 f \,d{x}$$
 
 이 된다.

--- a/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
+++ b/_posts/Mathematics/Measure Theory/2023-06-20-comparison-with-riemann-integral.md
@@ -17,7 +17,7 @@ image:
 
 먼저 혼동을 막기 위해 Lebesgue measure $m$에 대하여 르벡 적분을
 
-$$\int _{[a, b]} f \,d{m} = \int _{[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
+$$\int_ {[a, b]} f \,d{m} = \int_ {[a, b]} f \,d{x} = \int_a^b f \,d{x}$$
 
 와 같이 표기하고, 리만 적분은
 
@@ -35,39 +35,39 @@ $$\mathcal{R}\int_a^b f\,d{x}$$
 
 또한 (2)는 리만 적분 가능성에 대한 동치 조건을 알려줍니다. Almost everywhere라는 조건이 붙었기 때문에, $\mathcal{L}^1$의 equivalence class를 고려하면 사실상 연속함수에 대해서만 리만 적분이 가능하다는 뜻이 됩니다.
 
-**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x _{n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P _{k+1}$ (refinement) 이고 $\lvert x _{i}^k - x _{i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
+**증명.** $k \in \mathbb{N}$ 에 대하여 구간 $[a, b]$의 분할 $P_k = \lbrace a = x_0^k < x_1^k < \cdots < x_ {n_k}^k = b\rbrace$ 를 잡는다. 단 $P_k \subseteq P_ {k+1}$ (refinement) 이고 $\lvert x_ {i}^k - x_ {i-1}^k \rvert < \frac{1}{k}$ 이 되도록 한다.
 
 그러면 리만 적분의 정의로부터
 
-$$\lim _{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int _{a}^{b}} f\,d{x}, \quad \lim _{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int _{a}^{b}} f \,d{x}$$
+$$\lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x}, \quad \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x}$$
 
 임을 알 수 있다.
 
 이제 measurable simple function $U_k, L_k$를 다음과 같이 잡는다.
 
-$$U_k = \sum _{i=1}^{n_k} \sup _{x _{i-1}^k \leq y \leq x _{i}^k} f(y) \chi _{(x _{i-1}^k, x_i^k]}, \quad L_k = \sum _{i=1}^{n_k} \inf _{x _{i-1}^k \leq y \leq x _{i}^k} f(y) \chi _{(x _{i-1}^k, x_i^k]}.$$
+$$U_k = \sum_ {i=1}^{n_k} \sup_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}, \quad L_k = \sum_ {i=1}^{n_k} \inf_ {x_ {i-1}^k \leq y \leq x_ {i}^k} f(y) \chi_ {(x_ {i-1}^k, x_i^k]}.$$
 
 그러면 구간 $[a, b]$ 위에서 $L_k \leq f \leq U_k$인 것은 당연하고, 르벡 적분이 가능하므로
 
 $$\int_a^b L_k \,d{x} = L(P_k, f), \quad \int_a^b U_k \,d{x} = U(P_k, f)$$
 
-이 됨을 알 수 있다. 여기서 $P_k \subseteq P _{k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
+이 됨을 알 수 있다. 여기서 $P_k \subseteq P_ {k + 1}$ 이 되도록 잡았기 때문에, $L_k$는 증가하는 수열, $U_k$는 감소하는 수열이다.
 
 그러므로
 
-$$L(x) = \lim _{k \rightarrow\infty} L_k(x), \quad U(x) = \lim _{k \rightarrow\infty} U_k(x)$$
+$$L(x) = \lim_ {k \rightarrow\infty} L_k(x), \quad U(x) = \lim_ {k \rightarrow\infty} U_k(x)$$
 
 로 정의했을 때, 극한이 존재함을 알 수 있다. 여기서 $f, L_k, U_k$가 모두 유계인 함수이므로 지배 수렴 정리에 의해
 
-$$\int_a^b L \,d{x} = \lim _{k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim _{k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int _{a}^{b}} f\,d{x} < \infty,$$
+$$\int_a^b L \,d{x} = \lim_ {k \rightarrow\infty} \int_a^b L_k \,d{x} = \lim_ {k \rightarrow\infty} L(P_k, f) = \mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} < \infty,$$
 
-$$\int_a^b U\,d{x} = \lim _{k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim _{k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int _{a}^{b}} f \,d{x} < \infty$$
+$$\int_a^b U\,d{x} = \lim_ {k \rightarrow\infty} \int_a^b U_k \,d{x} = \lim_ {k \rightarrow\infty} U(P_k, f) = \mathcal{R} \overline{\int_ {a}^{b}} f \,d{x} < \infty$$
 
 이므로 $L, U \in \mathcal{L}^{1}[a, b]$ 이다.
 
 위 사실을 종합하면 $f \in \mathcal{R}[a, b]$ 일 때,
 
-$$\mathcal{R}\underline{\int _{a}^{b}} f\,d{x} = \mathcal{R}\overline{\int _{a}^{b}} f\,d{x}$$
+$$\mathcal{R}\underline{\int_ {a}^{b}} f\,d{x} = \mathcal{R}\overline{\int_ {a}^{b}} f\,d{x}$$
 
 이므로
 
@@ -79,29 +79,29 @@ $$\int_a^b (U - L)\,d{x} = 0$$
 
 $$\int_a^b f \,d{x} = \mathcal{R}\int_a^b f\,d{x} < \infty \implies f \in \mathcal{L}^{1}[a, b].$$
 
-(2) 만약 $x \notin \bigcup _{k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t _{j_0-1}^n, t _{j_0}^n)$ 이면서
+(2) 만약 $x \notin \bigcup_ {k=1}^{\infty} P_k$ 라고 가정하면, 임의의 $\epsilon > 0$ 에 대해 충분히 큰 $n \in \mathbb{N}$ 을 잡았을 때 적당한 $j_0 \in \mathbb{N}$ 이 존재하여 $x \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 이면서
 
 $$\lvert L_n(x) - L(x) \rvert + \lvert U_n(x) - U(x) \rvert < \epsilon$$
 
-이 되도록 할 수 있다. 그러면 $y \in (t _{j_0-1}^n, t _{j_0}^n)$ 일 때
+이 되도록 할 수 있다. 그러면 $y \in (t_ {j_0-1}^n, t_ {j_0}^n)$ 일 때
 
-$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M _{j_0}^n - m _{j_0}^n = M _{j_0}^n - U(x) + U(x) - L(x) + L(x) - m _{j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
+$$\begin{aligned}        \lvert f(x) - f(y) \rvert & \leq M_ {j_0}^n - m_ {j_0}^n = M_ {j_0}^n - U(x) + U(x) - L(x) + L(x) - m_ {j_0}^n \\                          & \leq U(x) - L(x) + \epsilon    \end{aligned}$$
 
 가 됨을 알 수 있다.
 
-위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup _{k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
+위 부등식에 의해 $y \in \lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k$ 이면 $f$가 $y$에서 연속임을 알 수 있게 된다.
 
 따라서, $f$가 연속인 점들의 집합을 $C_f$라 하면
 
-$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup _{k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
+$$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup_ {k=1}^{\infty} P_k \subseteq C_f \subseteq\lbrace x : U(x) = L(x)\rbrace$$
 
-이 된다. 한편 $\bigcup _{k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
+이 된다. 한편 $\bigcup_ {k=1}^{\infty} P_k$는 measure가 0 이므로, $U = L$ $m$-a.e. 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다. 위 논의의 결과를 이용하면 $f \in \mathcal{R}[a, b]$ 인 것과 $f$가 연속 $m$-a.e. 인 것은 동치이다.
 
 아래는 증명의 부산물입니다.
 
 **참고.**
 
-1. $x \notin \bigcup _{k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
+1. $x \notin \bigcup_ {k=1}^\infty P_k$ 이면 $f$가 $x$에서 연속 $\iff f(x) = U(x) = L(x)$ 이다.
 
 2. $L(x) \leq f(x) \leq U(x)$ 이고 measurable function의 극한인 $L(x), U(x)$ 또한 measurable이다.
 
@@ -109,20 +109,20 @@ $$\lbrace x : U(x) = L(x)\rbrace \setminus\bigcup _{k=1}^{\infty} P_k \subseteq 
 
 이제 리만 적분의 유용한 성질들을 가지고 와서 사용할 수 있습니다.
 
-1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi _{[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
+1. $f \geq 0$ 이고 measurable일 때, $f_n = f\chi_ {[0, n]}$으로 정의한다. 단조 수렴 정리에 의해
 
-	$$\int_0^\infty f \,d{x} = \lim _{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim _{n \rightarrow\infty} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x}$$
 
 	이다. 마지막 적분을 리만 적분으로 계산할 수 있다.
 
-2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi _{[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
+2. 닫힌 유계 구간 $I \subseteq(0, \infty)$ 에 대하여 $f \in \mathcal{R}(I)$ 라 하면 $f \in \mathcal{L}^{1}(I)$ 이다. $f_n = f\chi_ {[0, n]}$ 으로 잡으면 $\lvert f_n \rvert \leq f$ 이므로 지배 수렴 정리를 적용하여
 
-	$$\int_0^\infty f \,d{x} = \lim _{n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim _{n \rightarrow\infty} \int_0^n f \,d{x} = \lim _{n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
+	$$\int_0^\infty f \,d{x} = \lim_ {n \rightarrow\infty} \int_0^\infty f_n \,d{x} = \lim_ {n \rightarrow\infty} \int_0^n f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R} \int_0^n f \,d{x}$$
 
 	임을 알 수 있다.
 
-마찬가지로 $f_n = f\chi _{(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
+마찬가지로 $f_n = f\chi_ {(1/n, 1)}$ 으로 잡은 경우에도 지배 수렴 정리에 의해
 
-$$\int_0^1 f\,d{x} = \lim _{n \rightarrow\infty} \int _{0}^1 f_n \,d{x} = \lim _{n \rightarrow\infty}\int _{1/n}^1 f \,d{x} = \lim _{n \rightarrow\infty} \mathcal{R}\int _{1/n}^1 f \,d{x}$$
+$$\int_0^1 f\,d{x} = \lim_ {n \rightarrow\infty} \int_ {0}^1 f_n \,d{x} = \lim_ {n \rightarrow\infty}\int_ {1/n}^1 f \,d{x} = \lim_ {n \rightarrow\infty} \mathcal{R}\int_ {1/n}^1 f \,d{x}$$
 
 이 된다.


### PR DESCRIPTION
_ keep spaces between underscores to display the text normally _

_if no spaces exist, it will display as italic text_

_ similarly..._
_and also _